### PR TITLE
[#37] fix: typography와 Input에서 styled override가 적용

### DIFF
--- a/imgoing-frontend/src/components/Routine.tsx
+++ b/imgoing-frontend/src/components/Routine.tsx
@@ -1,0 +1,96 @@
+import React, { useState, useEffect } from 'react';
+import { TouchableHighlightProps } from 'react-native';
+import { SvgXml } from 'react-native-svg';
+import styled from 'styled-components/native';
+import { icon_bell } from '../../assets/svg';
+import CaptionTypo from './typography/CaptionTypo';
+import SubheadlineTypo from './typography/SubheadlineTypo';
+
+type GroupType = '루틴' | '즐겨찾기' | '북마크';
+
+interface RoutineProps {
+  minutes: number;
+  title: string;
+  defaultNotification: boolean;
+  group?: GroupType;
+}
+
+const RoutineView = styled.View`
+  height: 50px;
+  border: 2px solid ${({ theme }) => theme.colors.black};
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 4px;
+  padding: 0 12px 0 16px;
+`;
+
+const Title = styled(SubheadlineTypo)`
+  flex: 1;
+  padding: 0 16px 0 10px;
+`;
+
+const GroupTagView = styled.View`
+  background-color: ${({ theme }) => theme.colors.grayHeavy};
+  height: 20px;
+  padding: 0 7px;
+  border-radius: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const GroupTag = styled(CaptionTypo)`
+  color: ${({ theme }) => theme.colors.white};
+`;
+
+const Bar = styled.View`
+  width: 2px;
+  height: 16px;
+  background-color: ${({ theme }) => theme.colors.grayDark};
+  border-radius: 100px;
+  margin: 0 12px 0 12px;
+`;
+
+const TouchableHighlight = styled.TouchableHighlight.attrs<TouchableHighlightProps>((props) => {
+  return {
+    underlayColor: props.theme.colors.grayLight,
+    activeOpacity: 0.6,
+  };
+})``;
+
+const Routine = (props: RoutineProps) => {
+  const { title, minutes, group, defaultNotification } = props;
+  const [isNotification, setNotification] = useState<boolean>(defaultNotification);
+  useEffect(() => {
+    console.log(isNotification);
+  }, [isNotification]);
+  return (
+    <>
+      <TouchableHighlight onPress={() => alert('test')}>
+        <RoutineView>
+          {group && (
+            <>
+              <GroupTagView>
+                <GroupTag bold>{group}</GroupTag>
+              </GroupTagView>
+              <Bar></Bar>
+            </>
+          )}
+          <SubheadlineTypo>{minutes}분</SubheadlineTypo>
+          <Title numberOfLines={1} color="grayHeavy">
+            {title}
+          </Title>
+          <SvgXml
+            onPress={() => setNotification(!isNotification)}
+            xml={isNotification ? icon_bell.set : icon_bell.unset}
+            fill={'black'}
+          />
+        </RoutineView>
+      </TouchableHighlight>
+    </>
+  );
+};
+
+export default Routine;

--- a/imgoing-frontend/src/components/common/Input.tsx
+++ b/imgoing-frontend/src/components/common/Input.tsx
@@ -9,34 +9,35 @@ interface InputProps extends TextInputProps {
   title?: string;
 }
 
-interface OwnProps{
+interface OwnProps {
   isFocus: boolean;
 }
 
 const StyledInput = styled(TextInput)<OwnProps & InputProps>`
   width: 100%;
   height: 50px;
-  margin-top: ${({title}) => title && 16}px;
-  background: ${({theme}) => theme.colors.white};
-  border: 2px solid ${({theme, isFocus}) => isFocus ? theme.colors.blue : theme.colors.black}; 
+  margin-top: ${({ title }) => title && 14};
+  background: ${({ theme }) => theme.colors.white};
+  border: 2px solid ${({ theme, isFocus }) => (isFocus ? theme.colors.blue : theme.colors.black)};
   border-radius: 4px;
   font-size: 16px;
   padding: 13px 16px 14px 16px;
-`
-const InputWrapper = styled.View``
-
+`;
+const InputWrapper = styled.View``;
 
 const Input = (props: InputProps) => {
+  const { style, ...restProps } = props;
   const [isFocus, setFocus] = useState<boolean>(false);
   return (
-    <InputWrapper>
-      { props.title && <SubheadlineTypo color="grayHeavy">{props.title}</SubheadlineTypo> }
-      <StyledInput 
-        isFocus={isFocus} 
+    <InputWrapper style={style}>
+      {props.title && <SubheadlineTypo color="grayHeavy">{props.title}</SubheadlineTypo>}
+      <StyledInput
+        isFocus={isFocus}
         placeholderTextColor={colors.grayHeavy}
-        onFocus={() => setFocus(true)} 
-        onBlur={() => setFocus(false)} 
-        {...props} />
+        onFocus={() => setFocus(true)}
+        onBlur={() => setFocus(false)}
+        {...restProps}
+      />
     </InputWrapper>
   );
 };

--- a/imgoing-frontend/src/components/common/RectangleButton.tsx
+++ b/imgoing-frontend/src/components/common/RectangleButton.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { TouchableOpacityProps } from 'react-native';
+import { SvgXml } from 'react-native-svg';
+import styled from 'styled-components/native';
+import { colors } from '../../constants';
+import SubheadlineTypo from '../typography/SubheadlineTypo';
+
+interface RectangleButtonProps extends TouchableOpacityProps {
+  children: React.ReactNode;
+  leftIcon?: string;
+}
+
+const StyledButton = styled.TouchableOpacity`
+  background-color: ${({ theme }) => theme.colors.blueLight};
+  height: 50px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+`;
+const RectangleButton = (props: RectangleButtonProps) => {
+  const { children, leftIcon, ...restProps } = props;
+  return (
+    <StyledButton {...restProps}>
+      {leftIcon && <SvgXml style={{ marginRight: 8 }} xml={leftIcon} fill={colors.blue}></SvgXml>}
+      <SubheadlineTypo bold color="blue">
+        {children}
+      </SubheadlineTypo>
+    </StyledButton>
+  );
+};
+
+export default RectangleButton;

--- a/imgoing-frontend/src/components/typography/BaseTypo/index.tsx
+++ b/imgoing-frontend/src/components/typography/BaseTypo/index.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { StyleProp, TextProps, TextStyle } from 'react-native';
 import styled from 'styled-components/native';
 import { ColorScheme, typoStyle } from '../../../constants';
 
@@ -15,7 +16,7 @@ export interface OwnProps {
   fontSize: string;
 }
 
-export interface TypoProps {
+export interface TypoProps extends TextProps {
   children: React.ReactNode;
   en?: boolean;
   bold?: boolean;

--- a/imgoing-frontend/src/components/typography/BodyTypo.tsx
+++ b/imgoing-frontend/src/components/typography/BodyTypo.tsx
@@ -8,9 +8,15 @@ const typoHeight = {
 };
 
 const BodyTypo = (props: TypoProps) => {
-  const { children, en, bold, color } = props;
+  const { children, en, bold, color, ...restProps } = props;
   return (
-    <BaseTypo fontSize="20px" typoHeight={typoHeight} en={en} bold={bold} color={color}>
+    <BaseTypo
+      fontSize="20px"
+      typoHeight={typoHeight}
+      en={en}
+      bold={bold}
+      color={color}
+      {...restProps}>
       {children}
     </BaseTypo>
   );

--- a/imgoing-frontend/src/components/typography/CalloutTypo.tsx
+++ b/imgoing-frontend/src/components/typography/CalloutTypo.tsx
@@ -7,9 +7,15 @@ const typoHeight = {
 };
 
 const CalloutTypo = (props: TypoProps) => {
-  const { children, en, bold, color } = props;
+  const { children, en, bold, color, ...restProps } = props;
   return (
-    <BaseTypo fontSize="16px" typoHeight={typoHeight} en={en} bold={bold} color={color}>
+    <BaseTypo
+      fontSize="16px"
+      typoHeight={typoHeight}
+      en={en}
+      bold={bold}
+      color={color}
+      {...restProps}>
       {children}
     </BaseTypo>
   );

--- a/imgoing-frontend/src/components/typography/CaptionTypo.tsx
+++ b/imgoing-frontend/src/components/typography/CaptionTypo.tsx
@@ -7,9 +7,15 @@ const typoHeight = {
 };
 
 const CaptionTypo = (props: TypoProps) => {
-  const { children, en, bold, color } = props;
+  const { children, en, bold, color, ...restProps } = props;
   return (
-    <BaseTypo fontSize="11px" typoHeight={typoHeight} en={en} bold={bold} color={color}>
+    <BaseTypo
+      fontSize="11px"
+      typoHeight={typoHeight}
+      en={en}
+      bold={bold}
+      color={color}
+      {...restProps}>
       {children}
     </BaseTypo>
   );

--- a/imgoing-frontend/src/components/typography/ContentTypo.tsx
+++ b/imgoing-frontend/src/components/typography/ContentTypo.tsx
@@ -7,9 +7,15 @@ const typoHeight = {
 };
 
 const ContentTypo = (props: TypoProps) => {
-  const { children, en, bold, color } = props;
+  const { children, en, bold, color, ...restProps } = props;
   return (
-    <BaseTypo fontSize="13px" typoHeight={typoHeight} en={en} bold={bold} color={color}>
+    <BaseTypo
+      fontSize="13px"
+      typoHeight={typoHeight}
+      en={en}
+      bold={bold}
+      color={color}
+      {...restProps}>
       {children}
     </BaseTypo>
   );

--- a/imgoing-frontend/src/components/typography/FootnoteTypo.tsx
+++ b/imgoing-frontend/src/components/typography/FootnoteTypo.tsx
@@ -7,9 +7,15 @@ const typoHeight = {
 };
 
 const FootnoteTypo = (props: TypoProps) => {
-  const { children, en, bold, color } = props;
+  const { children, en, bold, color, ...restProps } = props;
   return (
-    <BaseTypo fontSize="12px" typoHeight={typoHeight} en={en} bold={bold} color={color}>
+    <BaseTypo
+      fontSize="12px"
+      typoHeight={typoHeight}
+      en={en}
+      bold={bold}
+      color={color}
+      {...restProps}>
       {children}
     </BaseTypo>
   );

--- a/imgoing-frontend/src/components/typography/HeadlineTypo.tsx
+++ b/imgoing-frontend/src/components/typography/HeadlineTypo.tsx
@@ -7,9 +7,15 @@ const typoHeight = {
 };
 
 const HeadlineTypo = (props: TypoProps) => {
-  const { children, en, bold, color } = props;
+  const { children, en, bold, color, ...restProps } = props;
   return (
-    <BaseTypo fontSize="24px" typoHeight={typoHeight} en={en} bold={bold} color={color}>
+    <BaseTypo
+      fontSize="24px"
+      typoHeight={typoHeight}
+      en={en}
+      bold={bold}
+      color={color}
+      {...restProps}>
       {children}
     </BaseTypo>
   );

--- a/imgoing-frontend/src/components/typography/LargeTitleTypo.tsx
+++ b/imgoing-frontend/src/components/typography/LargeTitleTypo.tsx
@@ -7,9 +7,15 @@ const typoHeight = {
 };
 
 const LargeTitleTypo = (props: TypoProps) => {
-  const { children, en, bold, color } = props;
+  const { children, en, bold, color, ...restProps } = props;
   return (
-    <BaseTypo fontSize="36px" typoHeight={typoHeight} en={en} bold={bold} color={color}>
+    <BaseTypo
+      fontSize="36px"
+      typoHeight={typoHeight}
+      en={en}
+      bold={bold}
+      color={color}
+      {...restProps}>
       {children}
     </BaseTypo>
   );

--- a/imgoing-frontend/src/components/typography/SubheadlineTypo.tsx
+++ b/imgoing-frontend/src/components/typography/SubheadlineTypo.tsx
@@ -7,9 +7,15 @@ const typoHeight = {
 };
 
 const SubheadlineTypo = (props: TypoProps) => {
-  const { children, en, bold, color } = props;
+  const { children, en, bold, color, ...restProps } = props;
   return (
-    <BaseTypo fontSize="14px" typoHeight={typoHeight} en={en} bold={bold} color={color}>
+    <BaseTypo
+      fontSize="14px"
+      typoHeight={typoHeight}
+      en={en}
+      bold={bold}
+      color={color}
+      {...restProps}>
       {children}
     </BaseTypo>
   );

--- a/imgoing-frontend/src/components/typography/TitleTypo.tsx
+++ b/imgoing-frontend/src/components/typography/TitleTypo.tsx
@@ -7,9 +7,15 @@ const typoHeight = {
 };
 
 const TitleTypo = (props: TypoProps) => {
-  const { children, en, bold, color } = props;
+  const { children, en, bold, color, ...restProps } = props;
   return (
-    <BaseTypo fontSize="30px" typoHeight={typoHeight} en={en} bold={bold} color={color}>
+    <BaseTypo
+      fontSize="30px"
+      typoHeight={typoHeight}
+      en={en}
+      bold={bold}
+      color={color}
+      {...restProps}>
       {children}
     </BaseTypo>
   );

--- a/imgoing-frontend/src/layouts/BottomButtonLayout.tsx
+++ b/imgoing-frontend/src/layouts/BottomButtonLayout.tsx
@@ -1,56 +1,76 @@
 import React from 'react';
-import { LinearGradient } from "expo-linear-gradient";
-import { KeyboardAvoidingView, Platform } from "react-native";
-import styled from "styled-components/native";
-import RoundButton from "../components/common/RoundButton";
+import { LinearGradient } from 'expo-linear-gradient';
+import { KeyboardAvoidingView, NativeModules, Platform } from 'react-native';
+import styled from 'styled-components/native';
+import RoundButton from '../components/common/RoundButton';
+import { useState, useEffect } from 'react';
 
 interface BottomButtonLayoutProps {
-    children: React.ReactNode;
-    text: string;
-    onPress: () => void;
+  children: React.ReactNode;
+  text: string;
+  onPress: () => void;
 }
 
 const BottomView = styled.View`
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    height: 90px;
-    display: flex;
-    justify-content: center;
-`
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 90px;
+  display: flex;
+  justify-content: center;
+`;
 
 const ButtonView = styled.View`
-    padding: 0 20px;
-`
+  padding: 0 20px;
+`;
 
 const GradientOverlay = styled(LinearGradient)`
-    height: 100%;
-    width: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: -1;
-`
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
+`;
 
 const BottomLayoutView = styled.View`
-    position: relative;
-`
+  position: relative;
+`;
+
+const { StatusBarManager } = NativeModules;
 
 const BottomButtonLayout = (props: BottomButtonLayoutProps) => {
-    const { children, text, onPress } = props;
-    return(
-        <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"}>
-            <BottomLayoutView>
-                {children}
-                <BottomView>
-                    <ButtonView>
-                        <RoundButton onPress={onPress}>{text}</RoundButton>
-                    </ButtonView>
-                    <GradientOverlay colors={['rgba(255,255,255,0)', 'rgba(255,255,255,1)' ,'rgba(255,255,255,1)']}></GradientOverlay>
-                </BottomView>
-            </BottomLayoutView>
-        </KeyboardAvoidingView>
-    )
-}
+  const [statusBarHeight, setStatusBarHeight] = useState(0);
+  const { children, text, onPress } = props;
+  useEffect(() => {
+    Platform.OS == 'ios'
+      ? StatusBarManager.getHeight((statusBarFrameData: any) => {
+          setStatusBarHeight(statusBarFrameData.height);
+        })
+      : null;
+  }, []);
+
+  useEffect(() => {}, []);
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={statusBarHeight + 44}>
+      <BottomLayoutView>
+        {children}
+        <BottomView>
+          <ButtonView>
+            <RoundButton onPress={onPress}>{text}</RoundButton>
+          </ButtonView>
+          <GradientOverlay
+            colors={[
+              'rgba(255,255,255,0)',
+              'rgba(255,255,255,1)',
+              'rgba(255,255,255,1)',
+            ]}></GradientOverlay>
+        </BottomView>
+      </BottomLayoutView>
+    </KeyboardAvoidingView>
+  );
+};
 
 export default BottomButtonLayout;

--- a/imgoing-frontend/src/screens/PlanEditScreen.tsx
+++ b/imgoing-frontend/src/screens/PlanEditScreen.tsx
@@ -1,40 +1,57 @@
 import React from 'react';
 import { ScrollView } from 'react-native';
 import styled from 'styled-components/native';
-import Input from "../components/common/Input";
+import { icon_plus } from '../../assets/svg';
+import Input from '../components/common/Input';
+import RectangleButton from '../components/common/RectangleButton';
+import Routine from '../components/Routine';
 import SubheadlineTypo from '../components/typography/SubheadlineTypo';
 import BottomButtonLayout from '../layouts/BottomButtonLayout';
 
-
-
 const EditView = styled.View`
-    height: 930px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    padding: 0 15px;
-    padding-top: 20px;
-    padding-bottom: 90px;
-    background: white;
-    
-`
+  padding: 0 15px;
+  padding-bottom: 90px;
+  padding-top: 20px;
+  background: white;
+`;
+
+const EditInput = styled(Input)`
+  margin-bottom: 40px;
+`;
 
 const EditScreen = () => {
-    return(
-        <BottomButtonLayout text="적용하기" onPress={() => {}}>
-            <ScrollView style={{backgroundColor: "white"}}>
-                <EditView>
-                    <Input title="스케줄 이름을 입력해 주세요" placeholder="스케줄 이름 입력하기" />
-                    <Input title="목적지를 입력해 주세요" placeholder="목적지 설정하기" />
-                    <Input title="도착 시간을 입력해 주세요" placeholder="날짜 / 시간 설정하기" />
-                    <Input title="외출 시 필요한 물품이 있나요?" placeholder="필요 물품 입력하기" />
-                    <Input style={{height: 150}} multiline={true} numberOfLines={4} title="일정에 대한 상세 내용을 알려주세요" placeholder="일정에 대한 상세 내용 입력하기" />
-                    <SubheadlineTypo color="grayHeavy">어떤 준비가 필요할까요?</SubheadlineTypo>
-                </EditView>
-            </ScrollView>
-        </BottomButtonLayout>
-    )
-}
- 
+  return (
+    <BottomButtonLayout text="적용하기" onPress={() => {}}>
+      <ScrollView style={{ backgroundColor: 'white' }}>
+        <EditView>
+          <EditInput title="스케줄 이름을 입력해 주세요" placeholder="스케줄 이름 입력하기" />
+          <EditInput title="목적지를 입력해 주세요" placeholder="목적지 설정하기" />
+          <EditInput title="도착 시간을 입력해 주세요" placeholder="날짜 / 시간 설정하기" />
+          <EditInput title="외출 시 필요한 물품이 있나요?" placeholder="필요 물품 입력하기" />
+          <EditInput
+            style={{ height: 150 }}
+            multiline={true}
+            numberOfLines={4}
+            title="일정에 대한 상세 내용을 알려주세요"
+            placeholder="일정에 대한 상세 내용 입력하기"
+          />
+          <SubheadlineTypo color="grayHeavy">어떤 준비가 필요할까요?</SubheadlineTypo>
+          <RectangleButton leftIcon={icon_plus}>등록해 주세요</RectangleButton>
+          <Routine
+            minutes={120}
+            defaultNotification={true}
+            title="옷 갈아입기 옷 갈아입기 옷 갈아입기..adadadadadadadadaddad"
+          />
+          <Routine
+            minutes={120}
+            defaultNotification={true}
+            title="옷 갈아입기 옷 갈아입기 옷 갈아입기..adadadadadadadadaddad"
+            group="루틴"
+          />
+        </EditView>
+      </ScrollView>
+    </BottomButtonLayout>
+  );
+};
 
-export default EditScreen;  
+export default EditScreen;


### PR DESCRIPTION
## 관련 이슈 연결
#38, #37 

## 변경/추가 사항, 자세한 설명
* typography와 Input에서 styled override가 적용되게 변경
* Routine, RectangleButton 컴포넌트 제작
* BottomButtonLayout의 Button이 키보드에 아래에 깔리던 문제 해결

## 그 외 그냥 하고 싶은 말
루틴 컴포넌트는 편집하기 페이지 외에 등록하기 페이지에서도 사용되는데 둘이 비슷하면서 달라서
이걸 한개의 컴포넌트로 만들어야하나 고민중입니다.

## 최종 결과물 스크린샷
![image](https://user-images.githubusercontent.com/66717787/137711875-63af36d3-10eb-4096-b5bd-61e6d1e40503.png)



