### PR TITLE
[Fix/PlanItem Text Error]: PlanItem에서 memo와 item이 없을때 비정상적으로 앱이 종료되는 문제

### DIFF
--- a/imgoing-frontend/src/components/HomeMain/PlanItem.tsx
+++ b/imgoing-frontend/src/components/HomeMain/PlanItem.tsx
@@ -145,8 +145,8 @@ const PlanItem = ({ item }: { item: Plan }) => {
             }}>
             <SvgXml xml={kakaoMap} width='100%' height='32px' />
           </KaKaoMapButton>
-          {items && <PlanItemDetail emoji={`🎒️`} content={items} />}
-          {memo && <PlanItemDetail emoji={`✏️`} content={memo} />}
+          {items.length > 0 && <PlanItemDetail emoji={`🎒️`} content={items} />}
+          {memo.length > 0 && <PlanItemDetail emoji={`✏️`} content={memo} />}
         </DetailView>
       )}
     </PlanItemView>


### PR DESCRIPTION
## 관련 이슈 연결
closes #107 

## 변경/추가 사항, 자세한 설명
* PlanItem에서 memo와 item이 없을때 비정상적으로 앱이 종료되는 문제를 수정하였습니다.




