### PR TITLE
[#117] fix: ScrollView의 아이템을 TouchableHightlight로 변경

### DIFF
--- a/imgoing-frontend/package.json
+++ b/imgoing-frontend/package.json
@@ -32,7 +32,7 @@
     "react-native-svg": "12.1.1",
     "react-native-web": "~0.13.12",
     "react-native-webview": "11.6.2",
-    "react-native-wheel-scrollview-picker": "^1.2.2",
+    "react-native-wheel-scrollview-picker": "https://github.com/eun-seong/react-native-wheel-scrollview-picker.git",
     "react-navigation": "^4.4.4",
     "react-navigation-stack": "^2.10.4",
     "react-query": "^3.27.0",

--- a/imgoing-frontend/yarn.lock
+++ b/imgoing-frontend/yarn.lock
@@ -6049,10 +6049,9 @@ react-native-webview@11.6.2:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
-react-native-wheel-scrollview-picker@^1.2.2:
+"react-native-wheel-scrollview-picker@https://github.com/eun-seong/react-native-wheel-scrollview-picker.git":
   version "1.2.2"
-  resolved "https://registry.yarnpkg.com/react-native-wheel-scrollview-picker/-/react-native-wheel-scrollview-picker-1.2.2.tgz#ee9d73416951f9e249ad2e94754dc6f0911ee5a1"
-  integrity sha512-Fl/tzrkQl9R0q3mNaoY2nePA69CgjMP8uEiSFcPHumGpa6z9KALHoSIes3jJs9CIpz/E5Vlg50m5a/CnwDzf0A==
+  resolved "https://github.com/eun-seong/react-native-wheel-scrollview-picker.git#4b98435740cf1a31296c2a1b5ddabcb897a4530b"
 
 "react-native@https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz":
   version "0.63.2"


### PR DESCRIPTION
## 관련 이슈 연결
* it closes #117 

## 변경/추가 사항, 자세한 설명
> 기존 패키지 코드
```js
        <View style={[styles.itemWrapper, { height: itemHeight }]} key={index}>
          {item}
        </View>
```

> 변경된 코드
```js

      <TouchableHighlight key={index}>
        <View style={[styles.itemWrapper, { height: itemHeight }]}>
          {item}
        </View>
      </TouchableHighlight>
```
Modal에서 ScrollView가 왜 안되는지 전혀 모르겠지만.. 뭔가 이슈가 있나보더군요. 찾아본 결과 커뮤니티에서도 말이 많았습니다.
결국 야매로 `TouchableHighlight`로 감싸는 걸로 해결했습니다.


## 그 외 그냥 하고 싶은 말
🤦‍♀️.🤦‍♀️.아 시간이 너무 아깝습니다아

## 최종 결과물 스크린샷


