### PR TITLE
[Feat/input limit] 긴 글 input 적용

### DIFF
--- a/imgoing-frontend/src/components/PlanAdd/UserInput.tsx
+++ b/imgoing-frontend/src/components/PlanAdd/UserInput.tsx
@@ -113,7 +113,11 @@ const Step5 = ({ setInputText }: UserInputProps) => {
 const Step6 = ({ setInputText }: UserInputProps) => {
   return (
     <EditInput
+      long
       title='일정에 대한 상세 내용을 알려주세요'
+      maxLength={100}
+      multiline
+      numberOfLines={4}
       placeholder='상세 내용 입력하기'
       onChangeText={(text) => setInputText({ type: 'details', text })}
       defaultValue={store.getState().stepOfAddingPlan.userInputs.details || ''}

--- a/imgoing-frontend/src/components/PlanEdit/EditInputList.tsx
+++ b/imgoing-frontend/src/components/PlanEdit/EditInputList.tsx
@@ -86,6 +86,9 @@ const EditInputList = (props: EditInputListProps) => {
       title: '일정에 대한 상세 내용을 알려주세요',
       placeholder: '일정에 대한 상세 내용 입력하기',
       value: data.memo,
+      long: true,
+      maxLength: 100,
+      multiline: true,
     },
   ];
   return (

--- a/imgoing-frontend/src/components/common/Input.tsx
+++ b/imgoing-frontend/src/components/common/Input.tsx
@@ -48,7 +48,7 @@ const StyledInput = styled(TextInput)<OwnProps & InputProps>`
 
 const InputWrapper = styled.View``;
 
-const WordCount = styled.View`
+const WordCountView = styled.View`
   align-items: flex-end;
   padding: 5px;
 `;
@@ -80,11 +80,11 @@ const Input = (props: InputProps) => {
         {...restProps}
       />
       {long && (
-        <WordCount>
+        <WordCountView>
           <CaptionTypo color={wordCount < 100 ? 'black' : 'red'}>
             {wordCount}/{props.maxLength}
           </CaptionTypo>
-        </WordCount>
+        </WordCountView>
       )}
     </InputWrapper>
   );

--- a/imgoing-frontend/src/components/common/Input.tsx
+++ b/imgoing-frontend/src/components/common/Input.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import styled, { css } from 'styled-components/native';
 
-import { SubheadlineTypo } from 'components/typography';
+import { CaptionTypo, SubheadlineTypo } from 'components/typography';
 import { colors } from 'constant/index';
 
 export type InputChangeEventType<
@@ -45,11 +45,19 @@ const StyledInput = styled(TextInput)<OwnProps & InputProps>`
     `;
   }}
 `;
+
 const InputWrapper = styled.View``;
+
+const WordCount = styled.View`
+  align-items: flex-end;
+  padding: 5px;
+`;
 
 const Input = (props: InputProps) => {
   const { style, onChange, name, long, ...restProps } = props;
   const [isFocus, setFocus] = useState<boolean>(false);
+  const [wordCount, setWordCount] = useState(0);
+
   return (
     <InputWrapper style={style}>
       {props.title && (
@@ -61,12 +69,23 @@ const Input = (props: InputProps) => {
         long={long}
         isFocus={isFocus}
         name={name}
-        onChange={(e) => onChange && onChange({ ...e, name: String(name) })}
+        onChange={(e) => {
+          setWordCount(e.nativeEvent.text.length);
+          onChange && onChange({ ...e, name: String(name) });
+        }}
         placeholderTextColor={colors.grayHeavy}
         onFocus={() => setFocus(true)}
         onBlur={() => setFocus(false)}
+        style={long && { textAlignVertical: 'top' }}
         {...restProps}
       />
+      {long && (
+        <WordCount>
+          <CaptionTypo color={wordCount < 100 ? 'black' : 'red'}>
+            {wordCount}/{props.maxLength}
+          </CaptionTypo>
+        </WordCount>
+      )}
     </InputWrapper>
   );
 };

--- a/imgoing-frontend/src/components/common/Input.tsx
+++ b/imgoing-frontend/src/components/common/Input.tsx
@@ -6,7 +6,7 @@ import {
   TextInputChangeEventData,
   TextInputProps,
 } from 'react-native';
-import styled from 'styled-components/native';
+import styled, { css } from 'styled-components/native';
 
 import { SubheadlineTypo } from 'components/typography';
 import { colors } from 'constant/index';
@@ -20,6 +20,7 @@ export type InputChangeEventType<
 export interface InputProps extends Omit<TextInputProps, 'onChange'> {
   title?: string;
   name?: string;
+  long?: boolean;
   onChange?: (e: InputChangeEventType) => void;
 }
 
@@ -29,17 +30,25 @@ interface OwnProps {
 
 const StyledInput = styled(TextInput)<OwnProps & InputProps>`
   width: 100%;
-  height: 50px;
   background: ${({ theme }) => theme.colors.white};
   border: 2px solid ${({ theme, isFocus }) => (isFocus ? theme.colors.blue : theme.colors.black)};
   border-radius: 4px;
   font-size: 16px;
   padding: 13px 16px 14px 16px;
+  ${(props) => {
+    if (props.long)
+      return css`
+        height: 150px;
+      `;
+    return css`
+      height: 50px;
+    `;
+  }}
 `;
 const InputWrapper = styled.View``;
 
 const Input = (props: InputProps) => {
-  const { style, onChange, name, ...restProps } = props;
+  const { style, onChange, name, long, ...restProps } = props;
   const [isFocus, setFocus] = useState<boolean>(false);
   return (
     <InputWrapper style={style}>
@@ -49,6 +58,7 @@ const Input = (props: InputProps) => {
         </SubheadlineTypo>
       )}
       <StyledInput
+        long={long}
         isFocus={isFocus}
         name={name}
         onChange={(e) => onChange && onChange({ ...e, name: String(name) })}

--- a/imgoing-frontend/src/components/common/Input.tsx
+++ b/imgoing-frontend/src/components/common/Input.tsx
@@ -56,7 +56,7 @@ const WordCount = styled.View`
 const Input = (props: InputProps) => {
   const { style, onChange, name, long, ...restProps } = props;
   const [isFocus, setFocus] = useState<boolean>(false);
-  const [wordCount, setWordCount] = useState(0);
+  const [wordCount, setWordCount] = useState<number>(0);
 
   return (
     <InputWrapper style={style}>

--- a/imgoing-frontend/src/components/common/Input.tsx
+++ b/imgoing-frontend/src/components/common/Input.tsx
@@ -35,15 +35,7 @@ const StyledInput = styled(TextInput)<OwnProps & InputProps>`
   border-radius: 4px;
   font-size: 16px;
   padding: 13px 16px 14px 16px;
-  ${(props) => {
-    if (props.long)
-      return css`
-        height: 150px;
-      `;
-    return css`
-      height: 50px;
-    `;
-  }}
+  height: ${(props) => (props.long ? 150 : 50)}px;
 `;
 
 const InputWrapper = styled.View``;
@@ -54,9 +46,9 @@ const WordCountView = styled.View`
 `;
 
 const Input = (props: InputProps) => {
-  const { style, onChange, name, long, ...restProps } = props;
+  const { style, onChange, name, long, value, ...restProps } = props;
   const [isFocus, setFocus] = useState<boolean>(false);
-  const [wordCount, setWordCount] = useState<number>(0);
+  const [wordCount, setWordCount] = useState<number>(value?.length || 0);
 
   return (
     <InputWrapper style={style}>
@@ -77,6 +69,7 @@ const Input = (props: InputProps) => {
         onFocus={() => setFocus(true)}
         onBlur={() => setFocus(false)}
         style={long && { textAlignVertical: 'top' }}
+        value={value}
         {...restProps}
       />
       {long && (


### PR DESCRIPTION
## 관련 이슈 연결
It will close #72 

## 변경/추가 사항, 자세한 설명
- 여러줄 입력하는 경우, 더 큰 input을 사용할 수 있도록 input 컴포넌트를 변경했습니다.
- 지금 인풋에서 long 이라는 prop을 추가하면 인풋박스 사이즈를 키우도록 설정했습니다.
- 기본 props인 maxLength와 multiline도 지정해줘야 합니다
- 현재 input 컴포넌트와 별개의 컴포넌트로 작성하려고도 했었는데, 그럼 중복이 많이 발생할 것 같아서 현재 컴포넌트를 확장하는 방식으로 했습니다.
- 기존 디자인 대로면 글자수 카운트가 인풋박스 안으로 들어가야하는데, 그건 좀 더 까다로울것같아서 일단 인풋박스 밖 오른쪽 하단에 표시하는걸로 적용했습니다.

## 그 외 그냥 하고 싶은 말
- input안에 wordCount라는 state를 만들어서 적용하고 있는데, 그렇게하니까 일단 지금 편집하기에서 볼 때 초기 글자수가 기존에 입력했던 글자수가 아닌 0으로 초기화되어있어서 작은 부분이지만 수정필요할것 같긴합니다.. ㅠㅠ

## 최종 결과물 스크린샷

![image](https://user-images.githubusercontent.com/35093128/140619736-e668f9d4-f794-4ba1-a69d-d1ee402ce064.png)

