### PR TITLE
[#139] fix : 엔터입력시 개행되지않도록 수정

### DIFF
--- a/imgoing-frontend/src/components/common/Input.tsx
+++ b/imgoing-frontend/src/components/common/Input.tsx
@@ -59,6 +59,7 @@ const Input = (props: InputProps) => {
       )}
       <StyledInput
         long={long}
+        blurOnSubmit={true}
         isFocus={isFocus}
         name={name}
         onChange={(e) => {


### PR DESCRIPTION
## 관련 이슈 연결
It will close #139 

## 변경/추가 사항, 자세한 설명
개행을 막는 방법이 찾아보니 방법은 조금 다양한 것 같았는데,
가장 간단한 방법이 `blurOnSubmit={true}`로 해주면 엔터누를시에 blur 처리되면서 인풋이 비활성화되도록하였습니다.
사용상에 문제없을것같은데.. 혹시 다른 의견있으시면 말씀해주세요!

## 그 외 그냥 하고 싶은 말
x

## 최종 결과물 스크린샷
x

