### PR TITLE
[Common] 타이포 그라피 설정 및 Text 컴포넌트 구현

### DIFF
--- a/packages/design-token/src/fonts/Metrics.ts
+++ b/packages/design-token/src/fonts/Metrics.ts
@@ -1,0 +1,6 @@
+import { Dimensions } from 'react-native';
+
+const { width, height } = Dimensions.get('window');
+
+export const SCREEN_WIDTH = width < height ? width : height;
+export const SCREEN_HEIGHT = width < height ? height : width;

--- a/packages/design-token/src/fonts/index.ts
+++ b/packages/design-token/src/fonts/index.ts
@@ -1,1 +1,140 @@
-export const fonts = {};
+import { SCREEN_WIDTH } from './Metrics';
+
+export const GUIDELINE_BASE_WIDTH = 375;
+
+export const FONT = {
+  R: 'AppleSDGothicNeoR00',
+  B: 'AppleSDGothicNeoB00',
+};
+
+export const scaleFont = (size: number) => SCREEN_WIDTH * (size / GUIDELINE_BASE_WIDTH);
+
+export type TypoType =
+  | 'BOLD_10'
+  | 'BOLD_11'
+  | 'BOLD_12'
+  | 'BOLD_14'
+  | 'BOLD_16'
+  | 'BOLD_18'
+  | 'BOLD_20'
+  | 'BOLD_24'
+  | 'BOLD_28'
+  | 'BOLD_32'
+  | 'BOLD_36'
+  | 'BOLD_40'
+  | 'REGULAR_10'
+  | 'REGULAR_11'
+  | 'REGULAR_12'
+  | 'REGULAR_14'
+  | 'REGULAR_16'
+  | 'REGULAR_18'
+  | 'REGULAR_20'
+  | 'REGULAR_24'
+  | 'REGULAR_28'
+  | 'REGULAR_32'
+  | 'REGULAR_36'
+  | 'REGULAR_40';
+
+export const Typo: {
+  [key in TypoType]: {
+    size: number;
+    weight: keyof typeof FONT;
+  };
+} = {
+  BOLD_10: {
+    size: 10,
+    weight: 'B',
+  },
+  BOLD_11: {
+    size: 11,
+    weight: 'B',
+  },
+  BOLD_12: {
+    size: 12,
+    weight: 'B',
+  },
+  BOLD_14: {
+    size: 14,
+    weight: 'B',
+  },
+  BOLD_16: {
+    size: 16,
+    weight: 'B',
+  },
+  BOLD_18: {
+    size: 18,
+    weight: 'B',
+  },
+  BOLD_20: {
+    size: 20,
+    weight: 'B',
+  },
+  BOLD_24: {
+    size: 24,
+    weight: 'B',
+  },
+  BOLD_28: {
+    size: 28,
+    weight: 'B',
+  },
+  BOLD_32: {
+    size: 32,
+    weight: 'B',
+  },
+  BOLD_36: {
+    size: 36,
+    weight: 'B',
+  },
+  BOLD_40: {
+    size: 40,
+    weight: 'B',
+  },
+  REGULAR_10: {
+    size: 10,
+    weight: 'R',
+  },
+  REGULAR_11: {
+    size: 11,
+    weight: 'R',
+  },
+  REGULAR_12: {
+    size: 12,
+    weight: 'R',
+  },
+  REGULAR_14: {
+    size: 14,
+    weight: 'R',
+  },
+  REGULAR_16: {
+    size: 16,
+    weight: 'R',
+  },
+  REGULAR_18: {
+    size: 18,
+    weight: 'R',
+  },
+  REGULAR_20: {
+    size: 20,
+    weight: 'R',
+  },
+  REGULAR_24: {
+    size: 24,
+    weight: 'R',
+  },
+  REGULAR_28: {
+    size: 28,
+    weight: 'R',
+  },
+  REGULAR_32: {
+    size: 32,
+    weight: 'R',
+  },
+  REGULAR_36: {
+    size: 36,
+    weight: 'R',
+  },
+  REGULAR_40: {
+    size: 40,
+    weight: 'R',
+  },
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,10 +3,6 @@
   "main": "./src/index.ts",
   "version": "1.0.0",
   "peerDependencies": {
-    "react": "16.13.1",
-    "react-native": "0.64.3"
-  },
-  "devDependencies": {
     "@types/styled-components-react-native": "^5.1.1",
     "design-token": "workspace:1.0.0",
     "react": "16.13.1",

--- a/packages/ui/src/components/Test.tsx
+++ b/packages/ui/src/components/Test.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Text, View } from "react-native";
+import React from 'react';
+import { Text, View } from 'react-native';
 
 export const Test = () => {
   return (

--- a/packages/ui/src/components/Text.tsx
+++ b/packages/ui/src/components/Text.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { StyleSheet, Text as RNText, TextProps as RNTextProps, View } from 'react-native';
+
+import { colors, FONT, Typo, TypoType, scaleFont } from 'design-token';
+
+interface TextProps extends RNTextProps {
+  fontType?: TypoType;
+  paragraph?: boolean;
+  color?: string;
+}
+
+const textStyles = (typo: TypoType = 'REGULAR_16', paragraph = false) => ({
+  fontFamily: FONT[Typo[typo].weight],
+  fontSize: scaleFont(Typo[typo].size),
+  ...(paragraph && { lineHeight: scaleFont(Typo[typo].size) * 1.5 }),
+});
+
+export const Text = ({ children, style, color, fontType, paragraph, ...restProps }: TextProps) => {
+  return (
+    <View>
+      <RNText
+        style={[textStyles(fontType, paragraph), styles.base, style, { ...(color && { color }) }]}
+        {...restProps}>
+        {children}
+      </RNText>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  base: {
+    color: colors.black,
+  },
+});

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,1 +1,2 @@
-export * from "./Test";
+export * from './Test';
+export * from './Text';


### PR DESCRIPTION
## 관련 이슈 연결
* it closes #184 

## 변경/추가 사항, 자세한 설명
* 타이포 그라피 설정
* Text 컴포넌트 구현

## 하고 싶은 말
> 사용법
```jsx
<Text fontType={'BOLD_16'} style={[styles.text]}>
  {/* ...children */}
</Text>
```
* Text 컴포넌트를 사용할 때 `react-native`가 아닌 **`ui` 모듈에서 import했는지** 잘 확인합시다🙌
* `fontType`의 디폴트값은 `REGULAR_16`입니다.
* **line-height가 있는 경우**, `paragraph` prop을 추가합니다.
   ```jsx
   <Text paragraph fontType={'BOLD_16'} style={[styles.text]}>
     {/* ...children */}
   </Text>
   ```

## 최종 결과물 스크린샷


