### PR TITLE
홈 화면 최상단 컴포넌트 시간 계산 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "scripts": {
     "start": "yarn workspace app start",
-    "json-server": "yarn workspace app json-server"
+    "json-server": "yarn workspace app json-server",
+    "lt": "lt --port 3000 --subdomain imgoing --print-requests"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,6 +18,7 @@
     "@reduxjs/toolkit": "^1.6.2",
     "axios": "^0.24.0",
     "date-fns": "^2.27.0",
+    "date-fns-tz": "^1.2.2",
     "design-token": "workspace:1.0.0",
     "expo": "~43.0.2",
     "expo-font": "~10.0.3",

--- a/packages/app/src/components/Home/Schedule/PlanDetails.tsx
+++ b/packages/app/src/components/Home/Schedule/PlanDetails.tsx
@@ -80,7 +80,7 @@ const PlanDetails = ({ plan }: { plan: Plan }) => {
       </PlanDetail>
       <PlanDetail detailType={'task'}>
         {plan.tasks.map((task) => (
-          <Task text={task.name} time={task.time} />
+          <Task key={task.id} text={task.name} time={task.time} />
         ))}
       </PlanDetail>
     </View>

--- a/packages/app/src/components/Home/Schedule/index.tsx
+++ b/packages/app/src/components/Home/Schedule/index.tsx
@@ -30,14 +30,14 @@ const Schedule = ({ active = false, plans, title }: Props) => {
         <Text fontType={'BOLD_14'}>{title === 'upcoming' ? '다가오는 일정' : '진행중인 일정'}</Text>
       </View>
       {schedulesByDate.map((schedule) => (
-        <View style={styles.container}>
+        <View key={schedule.date} style={styles.container}>
           <View style={styles.date}>
             <Text fontType={'REGULAR_14'} color={colors.grayDark}>
               {getMonth(schedule.date)}월 {getDate(schedule.date)}일 {getDay(schedule.date)}요일
             </Text>
           </View>
           {schedule.plans.map((plan) => (
-            <Plan active={active} plan={plan} />
+            <Plan key={plan.id} active={active} plan={plan} />
           ))}
         </View>
       ))}

--- a/packages/app/src/components/Home/TopContents/RemainingTime.tsx
+++ b/packages/app/src/components/Home/TopContents/RemainingTime.tsx
@@ -1,22 +1,15 @@
 import { colors } from 'design-token';
 import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
+import { differenceInCalendarDays } from 'date-fns';
 
 import { Text } from 'ui';
-import { HomeTopContentsType } from '../type';
-import { differenceInCalendarDays } from 'date-fns';
-import { TimeRemainingRefType } from './types';
+import { HomeTopContentsType, ProcessState, TimeRemainingRefType } from '../type';
+import { timeText } from 'utils/date';
 
 interface Props {
-  process: {
-    purpose: HomeTopContentsType;
-    duration: 1 | 60;
-    endTime: string;
-  };
+  process: ProcessState;
 }
-
-const ONE_MINUTES_BY_SECONDS = 60;
-const ONE_HOUR_BY_SECONDS = ONE_MINUTES_BY_SECONDS * 60;
 
 const purposeText: {
   [key in HomeTopContentsType]: string;
@@ -29,57 +22,15 @@ const purposeText: {
 const RemainingTime = forwardRef(({ process }: Props, ref: TimeRemainingRefType) => {
   const [remainingTimeText, setRemainingTimeText] = useState('');
 
-  // const getRemainingTimeText = useCallback(
-  //   (endTime: string, callback: (time: string | null) => void, duration: 1 | 60 = 1) => {
-  //     const remainingSeconds = differenceInSeconds(new Date(endTime), new Date());
-  //     let [hour, minuites, seconds] = calcRemainingTime(remainingSeconds);
-
-  //     const makeTimeToText = () => {
-  //       let remainingTimeText = '';
-  //       if (duration === 60) {
-  //         if (minuites - 1 === 0 && hour === 0) return;
-  //         minuites - 1 < 0 && hour--;
-  //         minuites = mod(minuites - 1, ONE_MINUTES_BY_SECONDS);
-  //         remainingTimeText = timeText`${hour && `${hour}시간 `}${minuites && `${minuites}분`}`;
-  //       } else if (duration === 1) {
-  //         if (seconds - 1 === 0 && minuites === 0) return;
-  //         seconds - 1 < 0 && minuites--;
-  //         seconds = mod(seconds - 1, ONE_MINUTES_BY_SECONDS);
-  //         remainingTimeText = timeText`${minuites && `${minuites}분 `}${seconds && `${seconds}초`}`;
-  //       }
-  //       callback(remainingTimeText);
-  //     };
-
-  //     if (intervalId.current) {
-  //       clearInterval(intervalId.current);
-  //     }
-  //     intervalId.current = setInterval(makeTimeToText, duration * 1000);
-
-  //     setTimeout(() => {
-  //       intervalId.current && clearInterval(intervalId.current);
-  //       callback(null);
-  //     }, remainingSeconds * 1000);
-  //   },
-  //   [process],
-  // );
-
-  // const updateRemainingTime = (time: string | null) => {
-  //   if (!time) {
-  //     updateProcess();
-  //   } else {
-  //     setRemainingTimeText(time);
-  //   }
-  // };
-
-  // useEffect(() => {
-  //   if (diffDays < 2) {
-  //     getRemainingTimeText(process.endTime, updateRemainingTime, process.duration);
-  //   }
-  // }, [process]);
-
   useImperativeHandle(ref, () => ({
-    forceUpdate: () => {
-      console.log('RemainingTime update');
+    forceUpdate: (hour, minuites, seconds) => {
+      let remainingTimeText = '';
+      if (process.duration === 60) {
+        remainingTimeText = timeText`${hour && `${hour}시간 `}${minuites && `${minuites}분`}`;
+      } else if (process.duration === 1) {
+        remainingTimeText = timeText`${minuites && `${minuites}분 `}${seconds && `${seconds}초`}`;
+      }
+      setRemainingTimeText(remainingTimeText);
     },
   }));
 

--- a/packages/app/src/components/Home/TopContents/RemainingTime.tsx
+++ b/packages/app/src/components/Home/TopContents/RemainingTime.tsx
@@ -28,7 +28,9 @@ const RemainingTime = forwardRef(({ process }: Props, ref: TimeRemainingRefType)
       if (process.duration === 60) {
         remainingTimeText = timeText`${hour && `${hour}시간 `}${minuites && `${minuites}분`}`;
       } else if (process.duration === 1) {
-        remainingTimeText = timeText`${minuites && `${minuites}분 `}${seconds && `${seconds}초`}`;
+        remainingTimeText = timeText`${minuites && `${hour * 60 + minuites}분 `}${
+          seconds && `${seconds}초`
+        }`;
       }
       setRemainingTimeText(remainingTimeText);
     },

--- a/packages/app/src/components/Home/TopContents/RemainingTime.tsx
+++ b/packages/app/src/components/Home/TopContents/RemainingTime.tsx
@@ -26,7 +26,7 @@ const RemainingTime = forwardRef(({ process }: Props, ref: TimeRemainingRefType)
     forceUpdate: (hour, minuites, seconds) => {
       let remainingTimeText = '';
       if (process.duration === 60) {
-        remainingTimeText = timeText`${hour && `${hour}시간 `}${minuites && `${minuites}분`}`;
+        remainingTimeText = `${timeText`${hour && `${hour}시간 `}`}${minuites}분`;
       } else if (process.duration === 1) {
         remainingTimeText = timeText`${minuites && `${hour * 60 + minuites}분 `}${
           seconds && `${seconds}초`

--- a/packages/app/src/components/Home/TopContents/RemainingTime.tsx
+++ b/packages/app/src/components/Home/TopContents/RemainingTime.tsx
@@ -54,7 +54,7 @@ const RemainingTime = ({ process, updateProcess }: Props) => {
           if (seconds - 1 === 0 && minuites === 0) return;
           seconds - 1 < 0 && minuites--;
           seconds = mod(seconds - 1, ONE_MINUTES_BY_SECONDS);
-          remainingTimeText = timeText`${minuites && `${minuites}분 `}${seconds}초`;
+          remainingTimeText = timeText`${minuites && `${minuites}분 `}${seconds && `${seconds}초`}`;
         }
         callback(remainingTimeText);
       };

--- a/packages/app/src/components/Home/TopContents/RemainingTime.tsx
+++ b/packages/app/src/components/Home/TopContents/RemainingTime.tsx
@@ -24,6 +24,11 @@ const RemainingTime = forwardRef(({ process }: Props, ref: TimeRemainingRefType)
 
   useImperativeHandle(ref, () => ({
     forceUpdate: (hour, minuites, seconds) => {
+      if (hour < 0 || minuites < 0 || seconds < 0) {
+        setRemainingTimeText('');
+        return;
+      }
+
       let remainingTimeText = '';
       if (process.duration === 60) {
         remainingTimeText = `${timeText`${hour && `${hour}시간 `}`}${minuites}분`;

--- a/packages/app/src/components/Home/TopContents/RemainingTime.tsx
+++ b/packages/app/src/components/Home/TopContents/RemainingTime.tsx
@@ -7,6 +7,7 @@ import { HomeTopContentsType } from '../type';
 import { differenceInCalendarDays, differenceInSeconds } from 'date-fns';
 import { mod } from 'utils';
 import { timeText } from 'utils/date';
+import { calcRemainingTime } from './utils';
 
 interface Props {
   process: {
@@ -35,15 +36,10 @@ const RemainingTime = ({ process, updateProcess }: Props) => {
 
   const getRemainingTimeText = useCallback(
     (endTime: string, callback: (time: string | null) => void, duration: 1 | 60 = 1) => {
-      const remainingTime = differenceInSeconds(new Date(endTime), new Date());
-      const remianingMinuites = Math.floor(remainingTime / ONE_MINUTES_BY_SECONDS);
-      let [hour, minuites, seconds] = [
-        Math.floor(remianingMinuites / ONE_MINUTES_BY_SECONDS),
-        remianingMinuites % ONE_MINUTES_BY_SECONDS,
-        remainingTime % ONE_MINUTES_BY_SECONDS,
-      ];
+      const remainingSeconds = differenceInSeconds(new Date(endTime), new Date());
+      let [hour, minuites, seconds] = calcRemainingTime(remainingSeconds);
 
-      const makeTimeText = () => {
+      const makeTimeToText = () => {
         let remainingTimeText = '';
         if (duration === 60) {
           if (minuites - 1 === 0 && hour === 0) return;
@@ -59,23 +55,20 @@ const RemainingTime = ({ process, updateProcess }: Props) => {
         callback(remainingTimeText);
       };
 
-      makeTimeText();
-
       if (intervalId.current) {
         clearInterval(intervalId.current);
       }
-      intervalId.current = setInterval(makeTimeText, duration * 1000);
+      intervalId.current = setInterval(makeTimeToText, duration * 1000);
 
       setTimeout(() => {
         intervalId.current && clearInterval(intervalId.current);
         callback(null);
-      }, remainingTime * 1000);
+      }, remainingSeconds * 1000);
     },
     [process],
   );
 
   const updateRemainingTime = (time: string | null) => {
-    console.log('timupdateRemainingTime', time);
     if (!time) {
       updateProcess();
     } else {

--- a/packages/app/src/components/Home/TopContents/RemainingTime.tsx
+++ b/packages/app/src/components/Home/TopContents/RemainingTime.tsx
@@ -11,7 +11,7 @@ interface Props {
   purpose: HomeTopContentsType;
   startTime: string;
   endTime: string;
-  updateDuration: 1 | 60;
+  duration: 1 | 60;
   updatePurpose: () => void;
 }
 
@@ -44,7 +44,7 @@ const purposeText: {
   },
 };
 
-const RemainingTime = ({ purpose, startTime, endTime, updateDuration, updatePurpose }: Props) => {
+const RemainingTime = ({ purpose, startTime, endTime, duration, updatePurpose }: Props) => {
   let intervalId: NodeJS.Timer;
   const diffDays = differenceInCalendarDays(new Date(startTime), new Date());
   const [remainingTimeText, setRemainingTimeText] = useState('');
@@ -53,7 +53,7 @@ const RemainingTime = ({ purpose, startTime, endTime, updateDuration, updatePurp
     startTime: string,
     endTime: string,
     callback: (time: string | null) => void,
-    updateDuration: 1 | 60 = 1,
+    duration: 1 | 60 = 1,
   ) => {
     const remainingTime = differenceInSeconds(new Date(endTime), new Date(startTime));
     const remianingMinuites = Math.floor(remainingTime / ONE_MINUTES_BY_SECONDS);
@@ -68,12 +68,12 @@ const RemainingTime = ({ purpose, startTime, endTime, updateDuration, updatePurp
     }
     intervalId = setInterval(() => {
       let remainingTimeText = '';
-      if (updateDuration === 60) {
+      if (duration === 60) {
         if (minuites - 1 === 0 && hour === 0) return;
         minuites - 1 < 0 && hour--;
         minuites = mod(minuites - 1, ONE_MINUTES_BY_SECONDS);
         remainingTimeText = hour ? `${hour}시간 ${minuites}분` : `${minuites}분`;
-      } else if (updateDuration === 1) {
+      } else if (duration === 1) {
         if (seconds - 1 === 0 && minuites === 0) return;
         seconds - 1 < 0 && minuites--;
         seconds = mod(seconds - 1, ONE_MINUTES_BY_SECONDS);
@@ -81,7 +81,7 @@ const RemainingTime = ({ purpose, startTime, endTime, updateDuration, updatePurp
       }
 
       callback(remainingTimeText);
-    }, updateDuration * 1000);
+    }, duration * 1000);
 
     setTimeout(() => {
       clearInterval(intervalId);
@@ -126,7 +126,7 @@ const RemainingTime = ({ purpose, startTime, endTime, updateDuration, updatePurp
   // );
 
   useEffect(() => {
-    diffDays < 2 && getRemainingTimeText(startTime, endTime, updateRemainingTime, updateDuration);
+    diffDays < 2 && getRemainingTimeText(startTime, endTime, updateRemainingTime, duration);
   }, [purpose]);
 
   useEffect(() => {

--- a/packages/app/src/components/Home/TopContents/RemainingTime.tsx
+++ b/packages/app/src/components/Home/TopContents/RemainingTime.tsx
@@ -5,7 +5,7 @@ import { differenceInCalendarDays } from 'date-fns';
 
 import { Text } from 'ui';
 import { HomeTopContentsType, ProcessState, TimeRemainingRefType } from '../type';
-import { timeText } from 'utils/date';
+import { timeText, toSeoulDate } from 'utils/date';
 
 interface Props {
   process: ProcessState;
@@ -42,7 +42,10 @@ const RemainingTime = forwardRef(({ process }: Props, ref: TimeRemainingRefType)
   }));
 
   useEffect(() => {
-    const diffDays = differenceInCalendarDays(new Date(process.endTime), new Date());
+    const diffDays = differenceInCalendarDays(
+      toSeoulDate(process.endTime),
+      toSeoulDate(new Date()),
+    );
     if (diffDays > 3) {
       setRemainingTimeText(`${diffDays}일`);
     } else if (diffDays === 2) {

--- a/packages/app/src/components/Home/TopContents/RemainingTime.tsx
+++ b/packages/app/src/components/Home/TopContents/RemainingTime.tsx
@@ -78,12 +78,10 @@ const RemainingTime = ({ process, updateProcess }: Props) => {
   const updateRemainingTime = (time: string | null) => {
     console.log('timupdateRemainingTime', time);
     if (!time) {
-      const cur = new Date();
-      // purpose 설정 혹은 getRemainingTimeText 함수 다시 호출
-      return;
+      updateProcess();
+    } else {
+      setRemainingTimeText(time);
     }
-
-    setRemainingTimeText(time);
   };
 
   useEffect(() => {

--- a/packages/app/src/components/Home/TopContents/RemainingTime.tsx
+++ b/packages/app/src/components/Home/TopContents/RemainingTime.tsx
@@ -1,0 +1,196 @@
+import { colors } from 'design-token';
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { Text } from 'ui';
+import { HomeTopContentsType } from '../type';
+import { differenceInCalendarDays, differenceInSeconds } from 'date-fns';
+import { mod } from 'utils';
+
+interface Props {
+  purpose: HomeTopContentsType;
+  startTime: string;
+  endTime: string;
+  updateDuration: 1 | 60;
+  updatePurpose: () => void;
+}
+
+const ONE_MINUTES_BY_SECONDS = 60;
+const ONE_HOUR_BY_SECONDS = ONE_MINUTES_BY_SECONDS * 60;
+
+const purposeText: {
+  [key in HomeTopContentsType]: {
+    name: string;
+    convertTimeToText: (remainingTime: number) => string;
+  };
+} = {
+  oncoming: {
+    name: '약속 준비 시간',
+    convertTimeToText: (time) => {
+      return '';
+    },
+  },
+  process: {
+    name: '다음 준비 항목',
+    convertTimeToText: (time) => {
+      return '';
+    },
+  },
+  toArrival: {
+    name: '도착지',
+    convertTimeToText: (time) => {
+      return '';
+    },
+  },
+};
+
+const RemainingTime = ({ purpose, startTime, endTime, updateDuration, updatePurpose }: Props) => {
+  let intervalId: NodeJS.Timer;
+  const diffDays = differenceInCalendarDays(new Date(startTime), new Date());
+  const [remainingTimeText, setRemainingTimeText] = useState('');
+
+  const getRemainingTimeText = (
+    startTime: string,
+    endTime: string,
+    callback: (time: string | null) => void,
+    updateDuration: 1 | 60 = 1,
+  ) => {
+    const remainingTime = differenceInSeconds(new Date(endTime), new Date(startTime));
+    const remianingMinuites = Math.floor(remainingTime / ONE_MINUTES_BY_SECONDS);
+    let [hour, minuites, seconds] = [
+      Math.floor(remianingMinuites / ONE_MINUTES_BY_SECONDS),
+      remianingMinuites % ONE_MINUTES_BY_SECONDS,
+      remainingTime % ONE_MINUTES_BY_SECONDS,
+    ];
+
+    if (intervalId) {
+      clearInterval(intervalId);
+    }
+    intervalId = setInterval(() => {
+      let remainingTimeText = '';
+      if (updateDuration === 60) {
+        if (minuites - 1 === 0 && hour === 0) return;
+        minuites - 1 < 0 && hour--;
+        minuites = mod(minuites - 1, ONE_MINUTES_BY_SECONDS);
+        remainingTimeText = hour ? `${hour}시간 ${minuites}분` : `${minuites}분`;
+      } else if (updateDuration === 1) {
+        if (seconds - 1 === 0 && minuites === 0) return;
+        seconds - 1 < 0 && minuites--;
+        seconds = mod(seconds - 1, ONE_MINUTES_BY_SECONDS);
+        remainingTimeText = minuites ? `${minuites}분 ${seconds}초` : `${seconds}초`;
+      }
+
+      callback(remainingTimeText);
+    }, updateDuration * 1000);
+
+    setTimeout(() => {
+      clearInterval(intervalId);
+      callback(null);
+    }, remainingTime * 1000);
+  };
+
+  const updateRemainingTime = (time: string | null) => {
+    if (!time) {
+      const cur = new Date();
+      // purpose 설정 혹은 getRemainingTimeText 함수 다시 호출
+      return;
+    }
+
+    setRemainingTimeText(time);
+  };
+
+  // const remainingTimeToText = () => {
+  //   if (diffDays > 3) return `${diffDays}일`;
+  //   if (diffDays == 2) return '이틀';
+
+  //   const remainingTime = differenceInSeconds(new Date(startAt), new Date());
+  //   const remianingMinuites = remainingTime % ONE_HOUR_BY_SECONDS;
+  //   const remianingSeconds = remianingMinuites % ONE_MINUTES_BY_SECONDS;
+
+  //   return purpose === 'process'
+  //     ? `${Math.floor(remainingTime / ONE_MINUTES_BY_SECONDS)}분 ${remianingSeconds}초`
+  //     : `${Math.floor(remainingTime / ONE_HOUR_BY_SECONDS)}시간 ${Math.floor(
+  //         remianingMinuites / ONE_MINUTES_BY_SECONDS,
+  //       )}분`;
+  // };
+
+  // useInterval(
+  //   () => {
+  //     setRemainingTimeText(remainingTimeToText());
+  //   },
+  //   diffDays < 2 && purpose === 'oncoming'
+  //     ? 1000 * ONE_MINUTES_BY_SECONDS
+  //     : purpose === 'process'
+  //     ? 1000
+  //     : null,
+  // );
+
+  useEffect(() => {
+    diffDays < 2 && getRemainingTimeText(startTime, endTime, updateRemainingTime, updateDuration);
+  }, [purpose]);
+
+  useEffect(() => {
+    if (diffDays > 3) {
+      setRemainingTimeText(`${diffDays}일`);
+      return;
+    }
+    if (diffDays === 2) {
+      setRemainingTimeText('이틀');
+      return;
+    }
+  }, []);
+
+  return (
+    <View style={styles.component}>
+      <View style={styles.purposeText}>
+        <Text fontType={'BOLD_14'} color={colors.grayDark}>
+          {purposeText[purpose].name}
+        </Text>
+        <Text fontType={'REGULAR_14'} color={colors.grayDark}>
+          {' '}
+          까지
+        </Text>
+      </View>
+      <View style={styles.remaingTimeText}>
+        <View>
+          <View style={styles.textDecoration} />
+          <Text fontType={'BOLD_32'}>{remainingTimeText}</Text>
+        </View>
+        <Text fontType={'REGULAR_24'} color={colors.grayDark}>
+          {' '}
+          남음
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  component: {
+    backgroundColor: colors.white,
+    paddingHorizontal: 20,
+  },
+  purposeText: {
+    flexDirection: 'row',
+    paddingTop: 4,
+  },
+  timeRemaining: {
+    backgroundColor: colors.white,
+    paddingHorizontal: 12,
+    paddingTop: 20,
+  },
+  textDecoration: {
+    position: 'absolute',
+    height: 16,
+    backgroundColor: colors.blueLight,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  },
+  remaingTimeText: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+  },
+});
+
+export default React.memo(RemainingTime);

--- a/packages/app/src/components/Home/TopContents/Task.tsx
+++ b/packages/app/src/components/Home/TopContents/Task.tsx
@@ -1,49 +1,97 @@
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import { LayoutAnimation, StyleSheet, View, ViewProps } from 'react-native';
 
 import { colors } from 'design-token';
 import { Text } from 'ui';
+import { TimeRemainingRefType } from '../type';
 
-interface Props {
-  active?: boolean;
+interface Props extends ViewProps {
   title: string;
   time: number;
 }
 
-const Task = ({ active = false, title, time }: Props) => {
-  console.log(title, time);
+const Task = ({ title, time, ...props }: Props) => {
   return (
-    <View style={[styles.container, { ...(active && styles.active) }]}>
+    <View
+      {...props}
+      style={[styles.container]}
+      onLayout={() => {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+      }}>
       <View style={styles.title}>
-        <Text fontType={'BOLD_16'} color={active ? colors.white : colors.grayDark}>
+        <Text fontType={'BOLD_16'} color={colors.grayDark}>
           {title}
         </Text>
       </View>
       <View style={[styles.flexRow, styles.time]}>
         <View style={styles.flexRow}>
-          <Text fontType={'BOLD_14'} color={active ? colors.white : colors.grayDark}>
+          <Text fontType={'BOLD_14'} color={colors.grayDark}>
             {time}
           </Text>
-          <Text fontType={'REGULAR_14'} color={active ? colors.white : colors.grayDark}>
+          <Text fontType={'REGULAR_14'} color={colors.grayDark}>
             분 일정
           </Text>
         </View>
         <View style={styles.flexRow}>
-          {active && <Text>💣 </Text>}
-          <Text fontType={'BOLD_14'} color={active ? colors.white : colors.black}>
-            {active
-              ? ``
-              : `${Math.floor(time / 60)
-                  .toString()
-                  .padStart(2, '0')}:${Math.floor(time % 60)
-                  .toString()
-                  .padStart(2, '0')}:00`}
+          <Text fontType={'BOLD_14'} color={colors.black}>
+            {`${Math.floor(time / 60)
+              .toString()
+              .padStart(2, '0')}:${Math.floor(time % 60)
+              .toString()
+              .padStart(2, '0')}:00`}
           </Text>
         </View>
       </View>
     </View>
   );
 };
+
+export const ActiveTask = forwardRef(
+  ({ title, time, ...props }: Props, ref: TimeRemainingRefType) => {
+    const [timerTime, setTimerTime] = useState('');
+
+    useImperativeHandle(ref, () => ({
+      forceUpdate: (hour, minuites, seconds) => {
+        setTimerTime(
+          `${hour.toString().padStart(2, '0')}:${minuites.toString().padStart(2, '0')}:${seconds
+            .toString()
+            .padStart(2, '0')}`,
+        );
+      },
+    }));
+
+    return (
+      <View
+        {...props}
+        style={[styles.container, styles.active]}
+        onLayout={() => {
+          LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        }}>
+        <View style={styles.title}>
+          <Text fontType={'BOLD_16'} color={colors.white}>
+            {title}
+          </Text>
+        </View>
+        <View style={[styles.flexRow, styles.time]}>
+          <View style={styles.flexRow}>
+            <Text fontType={'BOLD_14'} color={colors.white}>
+              {time}
+            </Text>
+            <Text fontType={'REGULAR_14'} color={colors.white}>
+              분 일정
+            </Text>
+          </View>
+          <View style={styles.flexRow}>
+            <Text>💣 </Text>
+            <Text fontType={'BOLD_14'} color={colors.white}>
+              {timerTime}
+            </Text>
+          </View>
+        </View>
+      </View>
+    );
+  },
+);
 
 const styles = StyleSheet.create({
   flexRow: {

--- a/packages/app/src/components/Home/TopContents/Task.tsx
+++ b/packages/app/src/components/Home/TopContents/Task.tsx
@@ -11,6 +11,7 @@ interface Props {
 }
 
 const Task = ({ active = false, title, time }: Props) => {
+  console.log(title, time);
   return (
     <View style={[styles.container, { ...(active && styles.active) }]}>
       <View style={styles.title}>
@@ -21,7 +22,7 @@ const Task = ({ active = false, title, time }: Props) => {
       <View style={[styles.flexRow, styles.time]}>
         <View style={styles.flexRow}>
           <Text fontType={'BOLD_14'} color={active ? colors.white : colors.grayDark}>
-            {Math.floor(time / 60)}
+            {time}
           </Text>
           <Text fontType={'REGULAR_14'} color={active ? colors.white : colors.grayDark}>
             분 일정
@@ -30,7 +31,13 @@ const Task = ({ active = false, title, time }: Props) => {
         <View style={styles.flexRow}>
           {active && <Text>💣 </Text>}
           <Text fontType={'BOLD_14'} color={active ? colors.white : colors.black}>
-            00:00:47
+            {active
+              ? ``
+              : `${Math.floor(time / 60)
+                  .toString()
+                  .padStart(2, '0')}:${Math.floor(time % 60)
+                  .toString()
+                  .padStart(2, '0')}:00`}
           </Text>
         </View>
       </View>

--- a/packages/app/src/components/Home/TopContents/TaskProcess.tsx
+++ b/packages/app/src/components/Home/TopContents/TaskProcess.tsx
@@ -12,8 +12,13 @@ interface Props {
 const TaskProcess = ({ tasks }: Props) => {
   return (
     <ScrollView horizontal contentContainerStyle={styles.container}>
-      {tasks.map((_, idx) => (
-        <Task title={'물 마시기💧'} time={60} active={idx === 0} />
+      {tasks.map((task, idx) => (
+        <Task
+          key={`${task.name}-${task.time}`}
+          title={task.name}
+          time={task.time}
+          active={idx === 0}
+        />
       ))}
     </ScrollView>
   );

--- a/packages/app/src/components/Home/TopContents/TaskProcess.tsx
+++ b/packages/app/src/components/Home/TopContents/TaskProcess.tsx
@@ -1,28 +1,43 @@
-import React from 'react';
-import { StyleSheet } from 'react-native';
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import { LayoutAnimation, StyleSheet } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
 import { Task as TaskType } from 'types';
 import Task from './Task';
+import { TimeRemainingRefType } from './types';
 
 interface Props {
   tasks: TaskType[];
 }
 
-const TaskProcess = ({ tasks }: Props) => {
+const TaskProcess = forwardRef(({ tasks }: Props, ref: TimeRemainingRefType) => {
+  const [clicked, setClicked] = useState<string[]>([]);
+
+  useImperativeHandle(ref, () => ({
+    forceUpdate: () => {
+      console.log('TaskProcess');
+    },
+  }));
+
   return (
     <ScrollView horizontal contentContainerStyle={styles.container}>
-      {tasks.map((task, idx) => (
-        <Task
-          key={`${task.name}-${task.time}`}
-          title={task.name}
-          time={task.time}
-          active={idx === 0}
-        />
-      ))}
+      {tasks
+        .filter((task) => new Date() < new Date(task.endTime))
+        .map((task, idx) => (
+          <Task
+            key={`${task.name}-${task.time}`}
+            title={task.name}
+            time={task.time}
+            active={idx === 0}
+            onTouchEnd={() => {
+              LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+              setClicked([...clicked, `${task.name}-${task.time}`]);
+            }}
+          />
+        ))}
     </ScrollView>
   );
-};
+});
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/app/src/components/Home/TopContents/TaskProcess.tsx
+++ b/packages/app/src/components/Home/TopContents/TaskProcess.tsx
@@ -1,40 +1,40 @@
-import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { LayoutAnimation, StyleSheet } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
 import { Task as TaskType } from 'types';
-import Task from './Task';
-import { TimeRemainingRefType } from './types';
+import { ProcessState, TimeRemainingRefType } from '../type';
+import Task, { ActiveTask } from './Task';
 
 interface Props {
   tasks: TaskType[];
+  process: ProcessState;
 }
 
-const TaskProcess = forwardRef(({ tasks }: Props, ref: TimeRemainingRefType) => {
-  const [clicked, setClicked] = useState<string[]>([]);
+const TaskProcess = forwardRef(({ process, tasks }: Props, ref: TimeRemainingRefType) => {
+  const [planedTask, setPlanedTask] = useState<TaskType[]>(
+    tasks.filter((task) => new Date() < new Date(task.endTime)),
+  );
 
-  useImperativeHandle(ref, () => ({
-    forceUpdate: () => {
-      console.log('TaskProcess');
-    },
-  }));
+  useEffect(() => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setPlanedTask(tasks.filter((task) => new Date() < new Date(task.endTime)));
+  }, [process]);
 
   return (
     <ScrollView horizontal contentContainerStyle={styles.container}>
-      {tasks
-        .filter((task) => new Date() < new Date(task.endTime))
-        .map((task, idx) => (
-          <Task
+      {planedTask.map((task, idx) =>
+        idx === 0 ? (
+          <ActiveTask
+            ref={ref}
             key={`${task.name}-${task.time}`}
             title={task.name}
             time={task.time}
-            active={idx === 0}
-            onTouchEnd={() => {
-              LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-              setClicked([...clicked, `${task.name}-${task.time}`]);
-            }}
           />
-        ))}
+        ) : (
+          <Task key={`${task.name}-${task.time}`} title={task.name} time={task.time} />
+        ),
+      )}
     </ScrollView>
   );
 });

--- a/packages/app/src/components/Home/TopContents/TaskProcess.tsx
+++ b/packages/app/src/components/Home/TopContents/TaskProcess.tsx
@@ -3,6 +3,7 @@ import { LayoutAnimation, StyleSheet } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
 import { Task as TaskType } from 'types';
+import { toSeoulDate } from 'utils/date';
 import { ProcessState, TimeRemainingRefType } from '../type';
 import Task, { ActiveTask } from './Task';
 
@@ -13,12 +14,12 @@ interface Props {
 
 const TaskProcess = forwardRef(({ process, tasks }: Props, ref: TimeRemainingRefType) => {
   const [planedTask, setPlanedTask] = useState<TaskType[]>(
-    tasks.filter((task) => new Date() < new Date(task.endTime)),
+    tasks.filter((task) => toSeoulDate(new Date()) < toSeoulDate(task.endTime)),
   );
 
   useEffect(() => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-    setPlanedTask(tasks.filter((task) => new Date() < new Date(task.endTime)));
+    setPlanedTask(tasks.filter((task) => toSeoulDate(new Date()) < toSeoulDate(task.endTime)));
   }, [process]);
 
   return (

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -39,7 +39,7 @@ const TopContents = ({ plan }: Props) => {
       newState.purpose = 'process';
       newState.duration = 1;
       newState.endTime = intendedPlans?.endTime || plan.departureAt;
-    } else if (cur < new Date(plan.arrivalAt)) {
+    } else if (new Date(plan.departureAt) < cur && cur < new Date(plan.arrivalAt)) {
       newState.purpose = 'toArrival';
       newState.endTime = plan.arrivalAt;
     }
@@ -51,6 +51,8 @@ const TopContents = ({ plan }: Props) => {
 
     const remainingSeconds = differenceInSeconds(new Date(newState.endTime), new Date());
     let [hour, minuites, seconds] = calcRemainingTime(remainingSeconds);
+    timeRemainingRef.current?.forceUpdate(hour, minuites, seconds);
+    taskActiveProcessRef.current?.forceUpdate(hour, minuites, seconds);
 
     if (intervalId.current) {
       clearInterval(intervalId.current);

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -1,30 +1,17 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
-import { add, differenceInCalendarDays, differenceInSeconds } from 'date-fns';
+import React, { useState } from 'react';
+import { View } from 'react-native';
+import { add, format } from 'date-fns';
 
-import { colors } from 'design-token';
-import { Text } from 'ui';
 import { Plan } from 'types';
 import Guide from './Guide';
 import TaskProcess from './TaskProcess';
 import { HomeTopContentsType } from '../type';
 import { isInProgress } from 'utils';
-import useInterval from 'hooks/useInterval';
+import RemainingTime from './RemainingTime';
 
 interface Props {
   plan: Plan;
 }
-
-const ONE_MINUTES_BY_SECONDS = 60;
-const ONE_HOUR_BY_SECONDS = ONE_MINUTES_BY_SECONDS * 60;
-
-const purposeText: {
-  [key in HomeTopContentsType]: string;
-} = {
-  oncoming: '약속 준비 시간',
-  process: '다음 준비 항목',
-  toArrival: '도착지',
-};
 
 const TopContents = ({ plan }: Props) => {
   const depertureTime = add(new Date(plan.startAt), {
@@ -38,98 +25,18 @@ const TopContents = ({ plan }: Props) => {
       : 'oncoming',
   );
 
-  const diffDays = differenceInCalendarDays(new Date(plan.startAt), new Date());
-  const remainingTimeToText = () => {
-    if (diffDays > 3) return `${diffDays}일`;
-    if (diffDays == 2) return '이틀';
-
-    const remainingTime = differenceInSeconds(new Date(plan.startAt), new Date());
-    const remianingMinuites = remainingTime % ONE_HOUR_BY_SECONDS;
-    const remianingSeconds = remianingMinuites % ONE_MINUTES_BY_SECONDS;
-
-    return `${Math.floor(remainingTime / ONE_HOUR_BY_SECONDS)}시간 ${Math.floor(
-      remianingMinuites / ONE_MINUTES_BY_SECONDS,
-    )}분 ${remianingSeconds}초`;
-  };
-  const [remainingTimeText, setRemainingTimeText] = useState(remainingTimeToText());
-
-  useInterval(
-    () => {
-      setRemainingTimeText(remainingTimeToText());
-    },
-    diffDays < 2 && purpose === 'oncoming'
-      ? 1000 * ONE_MINUTES_BY_SECONDS
-      : purpose === 'process'
-      ? 1000
-      : null,
-  );
-
   return (
     <View>
-      <View style={styles.component}>
-        <View style={styles.purposeText}>
-          <Text fontType={'BOLD_14'} color={colors.grayDark}>
-            {purposeText[purpose]}
-          </Text>
-          <Text fontType={'REGULAR_14'} color={colors.grayDark}>
-            {' '}
-            까지
-          </Text>
-        </View>
-        <View style={styles.remaingTimeText}>
-          <View>
-            <View style={styles.textDecoration} />
-            <Text fontType={'BOLD_32'}>{remainingTimeText}</Text>
-          </View>
-          <Text fontType={'REGULAR_24'} color={colors.grayDark}>
-            {' '}
-            남음
-          </Text>
-        </View>
-      </View>
+      <RemainingTime
+        purpose={'oncoming'}
+        startTime={format(new Date(), 'yyyy-MM-dd HH:mm:ss')}
+        endTime={'2022-01-22 01:48:00'}
+        updateDuration={1}
+        updatePurpose={() => {}}
+      />
       {purpose === 'process' ? <TaskProcess tasks={plan.tasks} /> : <Guide type={purpose} />}
     </View>
   );
 };
-
-const styles = StyleSheet.create({
-  component: {
-    backgroundColor: colors.white,
-    paddingHorizontal: 20,
-  },
-  purposeText: {
-    flexDirection: 'row',
-    paddingTop: 4,
-  },
-  timeRemaining: {
-    backgroundColor: colors.white,
-    paddingHorizontal: 12,
-    paddingTop: 20,
-  },
-  guide: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 13,
-    borderWidth: 2,
-    borderColor: colors.grayMedium,
-  },
-  guideText: {
-    marginLeft: 12,
-  },
-  remaingTimeText: {
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-  },
-  textDecoration: {
-    position: 'absolute',
-    height: 16,
-    backgroundColor: colors.blueLight,
-    bottom: 0,
-    left: 0,
-    right: 0,
-  },
-});
 
 export default TopContents;

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -31,10 +31,13 @@ const TopContents = ({ plan }: Props) => {
         endTime: plan.startAt,
       });
     } else if (cur < new Date(plan.departureAt)) {
+      const intendedPlans = plan.tasks.find(
+        (task) => new Date(task.startTime) <= new Date() && new Date() < new Date(task.endTime),
+      );
       setProcessTime({
         purpose: 'process',
         duration: 1,
-        endTime: '',
+        endTime: intendedPlans?.endTime || plan.departureAt,
       });
     } else if (cur < new Date(plan.arrivalAt)) {
       setProcessTime({

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -58,11 +58,11 @@ const TopContents = ({ plan }: Props) => {
       clearInterval(intervalId.current);
     }
     intervalId.current = setInterval(() => {
-      if (seconds - 1 < 0) {
+      if (seconds - newState.duration < 0) {
         if (minuites - 1 < 0) hour--;
         minuites = mod(minuites - 1, ONE_MINUTES_BY_SECONDS);
       }
-      seconds = mod(seconds - 1, ONE_MINUTES_BY_SECONDS);
+      seconds = mod(seconds - newState.duration, ONE_MINUTES_BY_SECONDS);
       timeRemainingRef.current?.forceUpdate(hour, minuites, seconds);
       taskActiveProcessRef.current?.forceUpdate(hour, minuites, seconds);
     }, newState.duration * 1000);

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { View } from 'react-native';
 
 import { Plan } from 'types';
@@ -6,53 +6,73 @@ import Guide from './Guide';
 import TaskProcess from './TaskProcess';
 import { HomeTopContentsType } from '../type';
 import RemainingTime from './RemainingTime';
+import { differenceInCalendarDays, differenceInSeconds } from 'date-fns';
+import { TimeRemainingRefFunc } from './types';
 
 interface Props {
   plan: Plan;
 }
 
+type ProcessState = {
+  purpose: HomeTopContentsType;
+  duration: 1 | 60;
+  endTime: string;
+};
+
 const TopContents = ({ plan }: Props) => {
-  const [processTime, setProcessTime] = useState<{
-    purpose: HomeTopContentsType;
-    duration: 1 | 60;
-    endTime: string;
-  }>({
+  const timeRemainingRef = useRef<TimeRemainingRefFunc>(null);
+
+  let intervalId = useRef<NodeJS.Timer>();
+  const [processTime, setProcessTime] = useState<ProcessState>({
     purpose: 'oncoming',
-    duration: 1,
+    duration: 60,
     endTime: plan.arrivalAt,
   });
 
   const updateProcess = () => {
     const cur = new Date();
-    if (cur < new Date(plan.startAt)) {
-      setProcessTime({
-        purpose: 'oncoming',
-        duration: 60,
-        endTime: plan.startAt,
-      });
-    } else if (cur < new Date(plan.departureAt)) {
+    const newState: ProcessState = {
+      purpose: 'oncoming',
+      duration: 60,
+      endTime: plan.startAt,
+    };
+    if (new Date(plan.startAt) < cur && cur < new Date(plan.departureAt)) {
       const intendedPlans = plan.tasks.find(
         (task) => new Date(task.startTime) <= new Date() && new Date() < new Date(task.endTime),
       );
-      setProcessTime({
-        purpose: 'process',
-        duration: 1,
-        endTime: intendedPlans?.endTime || plan.departureAt,
-      });
+      newState.purpose = 'process';
+      newState.duration = 1;
+      newState.endTime = intendedPlans?.endTime || plan.departureAt;
     } else if (cur < new Date(plan.arrivalAt)) {
-      setProcessTime({
-        purpose: 'toArrival',
-        duration: 60,
-        endTime: plan.arrivalAt,
-      });
+      newState.purpose = 'toArrival';
+      newState.endTime = plan.arrivalAt;
     }
+
+    setProcessTime(newState);
+
+    const remainingSeconds = differenceInSeconds(new Date(newState.endTime), new Date());
+    const diffDays = differenceInCalendarDays(new Date(newState.endTime), new Date());
+    if (diffDays >= 2) return;
+
+    if (intervalId.current) {
+      clearInterval(intervalId.current);
+    }
+    intervalId.current = setInterval(() => {
+      // update component
+      timeRemainingRef.current?.forceUpdate();
+    }, newState.duration * 1000);
+
+    setTimeout(() => {
+      intervalId.current && clearInterval(intervalId.current);
+      updateProcess();
+    }, remainingSeconds * 1000);
   };
 
   useEffect(updateProcess, []);
 
   return (
     <View>
-      <RemainingTime process={processTime} updateProcess={updateProcess} />
+      <RemainingTime process={processTime} ref={timeRemainingRef} />
       {processTime.purpose === 'process' ? (
         <TaskProcess tasks={plan.tasks} />
       ) : (

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
-import { add } from 'date-fns';
 
 import { Plan } from 'types';
 import Guide from './Guide';
@@ -23,30 +22,30 @@ const TopContents = ({ plan }: Props) => {
     endTime: plan.arrivalAt,
   });
 
-  const updateProcess = () => {};
-
-  useEffect(() => {
-    const today = new Date();
-    if (today < new Date(plan.startAt)) {
+  const updateProcess = () => {
+    const cur = new Date();
+    if (cur < new Date(plan.startAt)) {
       setProcessTime({
         purpose: 'oncoming',
         duration: 60,
         endTime: plan.startAt,
       });
-    } else if (today < new Date(plan.departureAt)) {
+    } else if (cur < new Date(plan.departureAt)) {
       setProcessTime({
         purpose: 'process',
         duration: 1,
         endTime: '',
       });
-    } else if (today < new Date(plan.arrivalAt)) {
+    } else if (cur < new Date(plan.arrivalAt)) {
       setProcessTime({
         purpose: 'toArrival',
         duration: 60,
         endTime: plan.arrivalAt,
       });
     }
-  }, []);
+  };
+
+  useEffect(updateProcess, []);
 
   return (
     <View>

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native';
 import { differenceInCalendarDays, differenceInSeconds } from 'date-fns';
 
 import { mod } from 'utils';
+import { toSeoulDate } from 'utils/date';
 import { Plan } from 'types';
 import { ProcessState, TimeRemainingRefFunc } from '../type';
 import Guide from './Guide';
@@ -27,20 +28,22 @@ const TopContents = ({ plan }: Props) => {
   });
 
   const getNewProcessState = () => {
-    const cur = new Date();
+    const cur = toSeoulDate(new Date());
     const newState: ProcessState = {
       purpose: 'oncoming',
       duration: 60,
       endTime: plan.startAt,
     };
-    if (new Date(plan.startAt) < cur && cur < new Date(plan.departureAt)) {
+    if (toSeoulDate(plan.startAt) < cur && cur < toSeoulDate(plan.departureAt)) {
       const intendedPlans = plan.tasks.find(
-        (task) => new Date(task.startTime) <= new Date() && new Date() < new Date(task.endTime),
+        (task) =>
+          toSeoulDate(task.startTime) <= toSeoulDate(new Date()) &&
+          toSeoulDate(new Date()) < toSeoulDate(task.endTime),
       );
       newState.purpose = 'process';
       newState.duration = 1;
       newState.endTime = intendedPlans?.endTime || plan.departureAt;
-    } else if (new Date(plan.departureAt) < cur && cur < new Date(plan.arrivalAt)) {
+    } else if (toSeoulDate(plan.departureAt) < cur && cur < toSeoulDate(plan.arrivalAt)) {
       newState.purpose = 'toArrival';
       newState.endTime = plan.arrivalAt;
     }
@@ -51,10 +54,16 @@ const TopContents = ({ plan }: Props) => {
     const newState = getNewProcessState();
     setProcessTime(newState);
 
-    const diffDays = differenceInCalendarDays(new Date(newState.endTime), new Date());
+    const diffDays = differenceInCalendarDays(
+      toSeoulDate(newState.endTime),
+      toSeoulDate(new Date()),
+    );
     if (diffDays >= 2) return;
 
-    const remainingSeconds = differenceInSeconds(new Date(newState.endTime), new Date());
+    const remainingSeconds = differenceInSeconds(
+      toSeoulDate(newState.endTime),
+      toSeoulDate(new Date()),
+    );
 
     let [hour, minuites, seconds] = calcRemainingTime(remainingSeconds);
     timeRemainingRef.current?.forceUpdate(hour, minuites, seconds);

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -77,6 +77,11 @@ const TopContents = ({ plan, refetch }: Props) => {
       intervalId.current && clearInterval(intervalId.current);
       updateProcess();
     }, remainingSeconds * 1000);
+
+    return () => {
+      if (intervalId.current) clearInterval(intervalId.current);
+      if (timerId.current) clearTimeout(timerId.current);
+    };
   };
 
   useEffect(updateProcess, [plan]);

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -1,12 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
-import { add, format } from 'date-fns';
+import { add } from 'date-fns';
 
 import { Plan } from 'types';
 import Guide from './Guide';
 import TaskProcess from './TaskProcess';
 import { HomeTopContentsType } from '../type';
-import { isInProgress } from 'utils';
 import RemainingTime from './RemainingTime';
 
 interface Props {
@@ -14,27 +13,49 @@ interface Props {
 }
 
 const TopContents = ({ plan }: Props) => {
-  const depertureTime = add(new Date(plan.startAt), {
-    minutes: plan.tasks.reduce((acc, cur) => acc + cur.time, 0),
+  const [processTime, setProcessTime] = useState<{
+    purpose: HomeTopContentsType;
+    duration: 1 | 60;
+    endTime: string;
+  }>({
+    purpose: 'oncoming',
+    duration: 1,
+    endTime: plan.arrivalAt,
   });
-  const [purpose, setPurpose] = useState<HomeTopContentsType>(
-    isInProgress(plan.startAt, plan.arrivalAt)
-      ? new Date() > depertureTime
-        ? 'toArrival'
-        : 'process'
-      : 'oncoming',
-  );
+
+  const updateProcess = () => {};
+
+  useEffect(() => {
+    const today = new Date();
+    if (today < new Date(plan.startAt)) {
+      setProcessTime({
+        purpose: 'oncoming',
+        duration: 60,
+        endTime: plan.startAt,
+      });
+    } else if (today < new Date(plan.departureAt)) {
+      setProcessTime({
+        purpose: 'process',
+        duration: 1,
+        endTime: '',
+      });
+    } else if (today < new Date(plan.arrivalAt)) {
+      setProcessTime({
+        purpose: 'toArrival',
+        duration: 60,
+        endTime: plan.arrivalAt,
+      });
+    }
+  }, []);
 
   return (
     <View>
-      <RemainingTime
-        purpose={'oncoming'}
-        startTime={format(new Date(), 'yyyy-MM-dd HH:mm:ss')}
-        endTime={'2022-01-22 01:48:00'}
-        updateDuration={1}
-        updatePurpose={() => {}}
-      />
-      {purpose === 'process' ? <TaskProcess tasks={plan.tasks} /> : <Guide type={purpose} />}
+      <RemainingTime process={processTime} updateProcess={updateProcess} />
+      {processTime.purpose === 'process' ? (
+        <TaskProcess tasks={plan.tasks} />
+      ) : (
+        <Guide type={processTime.purpose} />
+      )}
     </View>
   );
 };

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -21,6 +21,7 @@ type ProcessState = {
 
 const TopContents = ({ plan }: Props) => {
   const timeRemainingRef = useRef<TimeRemainingRefFunc>(null);
+  const taskActiveProcessRef = useRef<TimeRemainingRefFunc>(null);
 
   let intervalId = useRef<NodeJS.Timer>();
   const [processTime, setProcessTime] = useState<ProcessState>({
@@ -60,6 +61,7 @@ const TopContents = ({ plan }: Props) => {
     intervalId.current = setInterval(() => {
       // update component
       timeRemainingRef.current?.forceUpdate();
+      taskActiveProcessRef.current?.forceUpdate();
     }, newState.duration * 1000);
 
     setTimeout(() => {
@@ -74,7 +76,7 @@ const TopContents = ({ plan }: Props) => {
     <View>
       <RemainingTime process={processTime} ref={timeRemainingRef} />
       {processTime.purpose === 'process' ? (
-        <TaskProcess tasks={plan.tasks} />
+        <TaskProcess tasks={plan.tasks} ref={taskActiveProcessRef} />
       ) : (
         <Guide type={processTime.purpose} />
       )}

--- a/packages/app/src/components/Home/TopContents/index.tsx
+++ b/packages/app/src/components/Home/TopContents/index.tsx
@@ -12,22 +12,21 @@ import { calcRemainingTime, ONE_MINUTES_BY_SECONDS } from './utils';
 
 interface Props {
   plan: Plan;
-  refetch: () => void;
 }
 
-const TopContents = ({ plan, refetch }: Props) => {
+const TopContents = ({ plan }: Props) => {
   const timeRemainingRef = useRef<TimeRemainingRefFunc>(null);
   const taskActiveProcessRef = useRef<TimeRemainingRefFunc>(null);
 
-  let intervalId = useRef<NodeJS.Timer>();
-  let timerId = useRef<NodeJS.Timer>();
+  const intervalId = useRef<NodeJS.Timer>();
+  const timerId = useRef<NodeJS.Timer>();
   const [processTime, setProcessTime] = useState<ProcessState>({
     purpose: 'oncoming',
     duration: 60,
     endTime: plan.arrivalAt,
   });
 
-  const updateProcess = () => {
+  const getNewProcessState = () => {
     const cur = new Date();
     const newState: ProcessState = {
       purpose: 'oncoming',
@@ -45,17 +44,17 @@ const TopContents = ({ plan, refetch }: Props) => {
       newState.purpose = 'toArrival';
       newState.endTime = plan.arrivalAt;
     }
+    return newState;
+  };
 
+  const updateProcess = () => {
+    const newState = getNewProcessState();
     setProcessTime(newState);
 
     const diffDays = differenceInCalendarDays(new Date(newState.endTime), new Date());
     if (diffDays >= 2) return;
 
     const remainingSeconds = differenceInSeconds(new Date(newState.endTime), new Date());
-    if (remainingSeconds <= 0) {
-      refetch();
-      return;
-    }
 
     let [hour, minuites, seconds] = calcRemainingTime(remainingSeconds);
     timeRemainingRef.current?.forceUpdate(hour, minuites, seconds);

--- a/packages/app/src/components/Home/TopContents/types.ts
+++ b/packages/app/src/components/Home/TopContents/types.ts
@@ -1,0 +1,2 @@
+export type TimeRemainingRefFunc = { forceUpdate: () => void };
+export type TimeRemainingRefType = React.ForwardedRef<TimeRemainingRefFunc>;

--- a/packages/app/src/components/Home/TopContents/types.ts
+++ b/packages/app/src/components/Home/TopContents/types.ts
@@ -1,2 +1,0 @@
-export type TimeRemainingRefFunc = { forceUpdate: () => void };
-export type TimeRemainingRefType = React.ForwardedRef<TimeRemainingRefFunc>;

--- a/packages/app/src/components/Home/TopContents/utils/index.ts
+++ b/packages/app/src/components/Home/TopContents/utils/index.ts
@@ -1,0 +1,11 @@
+export const ONE_MINUTES_BY_SECONDS = 60;
+export const ONE_HOUR_BY_SECONDS = ONE_MINUTES_BY_SECONDS * 60;
+
+export const calcRemainingTime = (remainingSeconds: number) => {
+  const remianingMinuites = Math.floor(remainingSeconds / ONE_MINUTES_BY_SECONDS);
+  return [
+    Math.floor(remianingMinuites / ONE_MINUTES_BY_SECONDS),
+    remianingMinuites % ONE_MINUTES_BY_SECONDS,
+    remainingSeconds % ONE_MINUTES_BY_SECONDS,
+  ];
+};

--- a/packages/app/src/components/Home/type.tsx
+++ b/packages/app/src/components/Home/type.tsx
@@ -5,3 +5,14 @@ export interface HomeTopContents {
 }
 export type HomeTopContentsType = keyof HomeTopContents;
 export type GuideType = keyof Omit<HomeTopContents, 'process'>;
+
+export type ProcessState = {
+  purpose: HomeTopContentsType;
+  duration: 1 | 60;
+  endTime: string;
+};
+
+export type TimeRemainingRefFunc = {
+  forceUpdate: (hour: number, minuites: number, seconds: number) => void;
+};
+export type TimeRemainingRefType = React.ForwardedRef<TimeRemainingRefFunc>;

--- a/packages/app/src/modules/services/plan.ts
+++ b/packages/app/src/modules/services/plan.ts
@@ -1,7 +1,8 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { add, format } from 'date-fns';
 
 import env from 'environments';
-import { Plan, ResPlan } from 'types';
+import { Plan, ResPlan, Task } from 'types';
 
 export const planApi = createApi({
   reducerPath: 'planApi',
@@ -28,7 +29,21 @@ export const planApi = createApi({
           },
           belongings: plan.belongings,
           memo: plan.memo,
-          tasks: plan.task,
+          tasks: plan.task.reduce((tasks, cur, idx): Task[] => {
+            if (tasks.length === 0) {
+              return [{ ...cur, startTime: plan.startAt }];
+            }
+            return [
+              ...tasks,
+              {
+                ...cur,
+                startTime: format(
+                  add(new Date(tasks[idx - 1].startTime), { minutes: cur.time }),
+                  'yyyy-MM-dd HH:mm:ss',
+                ),
+              },
+            ];
+          }, [] as Task[]),
           startAt: plan.startAt,
         })),
     }),

--- a/packages/app/src/modules/services/plan.ts
+++ b/packages/app/src/modules/services/plan.ts
@@ -13,44 +13,46 @@ export const planApi = createApi({
     getPlans: builder.query<Plan[], void>({
       query: () => ({ url: '/plans' }),
       transformResponse: (response: { data: ResPlan[] }) =>
-        response.data.map((plan) => ({
-          id: plan.id,
-          name: plan.name,
-          arrivalAt: plan.arrivalAt,
-          arrival: {
-            name: plan.arrivalName,
-            lat: plan.arrivalLat,
-            lng: plan.arrivalLng,
-          },
-          departureAt: format(
-            add(new Date(plan.startAt), {
-              minutes: plan.task.reduce((acc, cur) => acc + cur.time, 0),
-            }),
-            'yyyy-MM-dd HH:mm:ss',
-          ),
-          departure: {
-            name: plan.departureName,
-            lat: plan.departureLat,
-            lng: plan.departureLng,
-          },
-          belongings: plan.belongings,
-          memo: plan.memo,
-          tasks: plan.task.reduce((tasks, cur, idx): Task[] => {
-            const startTime =
-              tasks.length === 0
-                ? plan.startAt
-                : format(
-                    add(new Date(tasks[idx - 1].startTime), { minutes: tasks[idx - 1].time }),
-                    'yyyy-MM-dd HH:mm:ss',
-                  );
-            const endTime = format(
-              add(new Date(startTime), { minutes: cur.time }),
+        response.data
+          .filter((plan) => new Date() < new Date(plan.arrivalAt))
+          .map((plan) => ({
+            id: plan.id,
+            name: plan.name,
+            arrivalAt: plan.arrivalAt,
+            arrival: {
+              name: plan.arrivalName,
+              lat: plan.arrivalLat,
+              lng: plan.arrivalLng,
+            },
+            departureAt: format(
+              add(new Date(plan.startAt), {
+                minutes: plan.task.reduce((acc, cur) => acc + cur.time, 0),
+              }),
               'yyyy-MM-dd HH:mm:ss',
-            );
-            return [...tasks, { ...cur, startTime, endTime }];
-          }, [] as Task[]),
-          startAt: plan.startAt,
-        })),
+            ),
+            departure: {
+              name: plan.departureName,
+              lat: plan.departureLat,
+              lng: plan.departureLng,
+            },
+            belongings: plan.belongings,
+            memo: plan.memo,
+            tasks: plan.task.reduce((tasks, cur, idx): Task[] => {
+              const startTime =
+                tasks.length === 0
+                  ? plan.startAt
+                  : format(
+                      add(new Date(tasks[idx - 1].startTime), { minutes: tasks[idx - 1].time }),
+                      'yyyy-MM-dd HH:mm:ss',
+                    );
+              const endTime = format(
+                add(new Date(startTime), { minutes: cur.time }),
+                'yyyy-MM-dd HH:mm:ss',
+              );
+              return [...tasks, { ...cur, startTime, endTime }];
+            }, [] as Task[]),
+            startAt: plan.startAt,
+          })),
     }),
   }),
 });

--- a/packages/app/src/modules/services/plan.ts
+++ b/packages/app/src/modules/services/plan.ts
@@ -44,7 +44,7 @@ export const planApi = createApi({
               {
                 ...cur,
                 startTime: format(
-                  add(new Date(tasks[idx - 1].startTime), { minutes: cur.time }),
+                  add(new Date(tasks[idx - 1].startTime), { minutes: tasks[idx - 1].time }),
                   'yyyy-MM-dd HH:mm:ss',
                 ),
               },

--- a/packages/app/src/modules/services/plan.ts
+++ b/packages/app/src/modules/services/plan.ts
@@ -3,6 +3,7 @@ import { add, format } from 'date-fns';
 
 import env from 'environments';
 import { Plan, ResPlan, Task } from 'types';
+import { toSeoulDate } from 'utils/date';
 
 export const planApi = createApi({
   reducerPath: 'planApi',
@@ -12,9 +13,9 @@ export const planApi = createApi({
   endpoints: (builder) => ({
     getPlans: builder.query<Plan[], void>({
       query: () => ({ url: '/plans' }),
-      transformResponse: (response: { data: ResPlan[] }) =>
-        response.data
-          .filter((plan) => new Date() < new Date(plan.arrivalAt))
+      transformResponse: ({ data }: { data: ResPlan[] }) =>
+        data
+          .filter((plan) => toSeoulDate(new Date()) < toSeoulDate(plan.arrivalAt))
           .map((plan) => ({
             id: plan.id,
             name: plan.name,
@@ -25,7 +26,7 @@ export const planApi = createApi({
               lng: plan.arrivalLng,
             },
             departureAt: format(
-              add(new Date(plan.startAt), {
+              add(toSeoulDate(plan.startAt), {
                 minutes: plan.task.reduce((acc, cur) => acc + cur.time, 0),
               }),
               'yyyy-MM-dd HH:mm:ss',
@@ -42,11 +43,13 @@ export const planApi = createApi({
                 tasks.length === 0
                   ? plan.startAt
                   : format(
-                      add(new Date(tasks[idx - 1].startTime), { minutes: tasks[idx - 1].time }),
+                      add(toSeoulDate(tasks[idx - 1].startTime), {
+                        minutes: tasks[idx - 1].time,
+                      }),
                       'yyyy-MM-dd HH:mm:ss',
                     );
               const endTime = format(
-                add(new Date(startTime), { minutes: cur.time }),
+                add(toSeoulDate(startTime), { minutes: cur.time }),
                 'yyyy-MM-dd HH:mm:ss',
               );
               return [...tasks, { ...cur, startTime, endTime }];

--- a/packages/app/src/modules/services/plan.ts
+++ b/packages/app/src/modules/services/plan.ts
@@ -36,19 +36,18 @@ export const planApi = createApi({
           belongings: plan.belongings,
           memo: plan.memo,
           tasks: plan.task.reduce((tasks, cur, idx): Task[] => {
-            if (tasks.length === 0) {
-              return [{ ...cur, startTime: plan.startAt }];
-            }
-            return [
-              ...tasks,
-              {
-                ...cur,
-                startTime: format(
-                  add(new Date(tasks[idx - 1].startTime), { minutes: tasks[idx - 1].time }),
-                  'yyyy-MM-dd HH:mm:ss',
-                ),
-              },
-            ];
+            const startTime =
+              tasks.length === 0
+                ? plan.startAt
+                : format(
+                    add(new Date(tasks[idx - 1].startTime), { minutes: tasks[idx - 1].time }),
+                    'yyyy-MM-dd HH:mm:ss',
+                  );
+            const endTime = format(
+              add(new Date(startTime), { minutes: cur.time }),
+              'yyyy-MM-dd HH:mm:ss',
+            );
+            return [...tasks, { ...cur, startTime, endTime }];
           }, [] as Task[]),
           startAt: plan.startAt,
         })),

--- a/packages/app/src/modules/services/plan.ts
+++ b/packages/app/src/modules/services/plan.ts
@@ -22,6 +22,12 @@ export const planApi = createApi({
             lat: plan.arrivalLat,
             lng: plan.arrivalLng,
           },
+          departureAt: format(
+            add(new Date(plan.startAt), {
+              minutes: plan.task.reduce((acc, cur) => acc + cur.time, 0),
+            }),
+            'yyyy-MM-dd HH:mm:ss',
+          ),
           departure: {
             name: plan.departureName,
             lat: plan.departureLat,

--- a/packages/app/src/screens/HomeScreen.tsx
+++ b/packages/app/src/screens/HomeScreen.tsx
@@ -12,8 +12,10 @@ import { useGetPlansQuery } from 'modules/services/plan';
 import { isInProgress } from 'utils';
 import { differenceInSeconds } from 'date-fns';
 import { Plan } from 'types';
+import { toSeoulDate } from 'utils/date';
 
 const HomeScreen = () => {
+  const [refreshing, setRefreshing] = useState(false);
   const { data = [], refetch } = useGetPlansQuery();
   const [planInProgress, setPlanInProgress] = useState<Plan | null>(null);
 
@@ -28,8 +30,8 @@ const HomeScreen = () => {
       setPlanInProgress(data[0]);
       timeoutId = setTimeout(() => {
         refetch();
-      }, (differenceInSeconds(new Date(data[0].arrivalAt), new Date()) + 1) * 1000);
-    }, differenceInSeconds(new Date(data[0].startAt), new Date()) * 1000);
+      }, (differenceInSeconds(toSeoulDate(data[0].arrivalAt), toSeoulDate(new Date())) + 1) * 1000);
+    }, differenceInSeconds(toSeoulDate(data[0].startAt), toSeoulDate(new Date())) * 1000);
 
     return () => {
       timeoutId && clearTimeout(timeoutId);

--- a/packages/app/src/screens/HomeScreen.tsx
+++ b/packages/app/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, StyleSheet, RefreshControl } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -10,14 +10,34 @@ import TopContents from 'components/Home/TopContents';
 import Schedule from 'components/Home/Schedule';
 import { useGetPlansQuery } from 'modules/services/plan';
 import { isInProgress } from 'utils';
+import { differenceInSeconds } from 'date-fns';
+import { Plan } from 'types';
 
 const HomeScreen = () => {
-  const { data, refetch } = useGetPlansQuery();
+  const { data = [], refetch } = useGetPlansQuery();
+  const [planInProgress, setPlanInProgress] = useState<Plan | null>(null);
+
+  useEffect(() => {
+    if (!data || !data.length) return;
+
+    let timeoutId: NodeJS.Timeout;
+    const curPlan = isInProgress(data[0].startAt, data[0].arrivalAt) ? data[0] : null;
+
+    setPlanInProgress(curPlan);
+    timeoutId = setTimeout(() => {
+      setPlanInProgress(data[0]);
+      timeoutId = setTimeout(() => {
+        refetch();
+      }, (differenceInSeconds(new Date(data[0].arrivalAt), new Date()) + 1) * 1000);
+    }, differenceInSeconds(new Date(data[0].startAt), new Date()) * 1000);
+
+    return () => {
+      timeoutId && clearTimeout(timeoutId);
+    };
+  }, [data]);
+
   if (!data) return <Text>Loading...</Text>;
   if (!data.length) return <Text>no data...</Text>;
-
-  const planInProgress = isInProgress(data[0].startAt, data[0].arrivalAt) ? data[0] : undefined;
-  const upcomingPlans = (planInProgress ? data?.slice(1) : data) || [];
 
   return (
     <SafeAreaView style={styles.container}>
@@ -30,11 +50,9 @@ const HomeScreen = () => {
         style={styles.mainContainer}
         contentContainerStyle={{ paddingBottom: 120 }}
         refreshControl={<RefreshControl refreshing={false} />}>
-        <TopContents plan={data[0]} refetch={refetch} />
+        <TopContents plan={data[0]} />
         {planInProgress && <Schedule active plans={[planInProgress]} title='inProgress' />}
-        {upcomingPlans && upcomingPlans.length && (
-          <Schedule plans={upcomingPlans} title='upcoming' />
-        )}
+        <Schedule plans={planInProgress ? data.slice(1) : data} title='upcoming' />
       </ScrollView>
     </SafeAreaView>
   );

--- a/packages/app/src/screens/HomeScreen.tsx
+++ b/packages/app/src/screens/HomeScreen.tsx
@@ -12,7 +12,7 @@ import { useGetPlansQuery } from 'modules/services/plan';
 import { isInProgress } from 'utils';
 
 const HomeScreen = () => {
-  const { data } = useGetPlansQuery();
+  const { data, refetch } = useGetPlansQuery();
   if (!data) return <Text>Loading...</Text>;
   if (!data.length) return <Text>no data...</Text>;
 
@@ -30,7 +30,7 @@ const HomeScreen = () => {
         style={styles.mainContainer}
         contentContainerStyle={{ paddingBottom: 120 }}
         refreshControl={<RefreshControl refreshing={false} />}>
-        <TopContents plan={data[0]} />
+        <TopContents plan={data[0]} refetch={refetch} />
         {planInProgress && <Schedule active plans={[planInProgress]} title='inProgress' />}
         {upcomingPlans && upcomingPlans.length && (
           <Schedule plans={upcomingPlans} title='upcoming' />

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -3,6 +3,7 @@ export type Task = {
   name: string;
   time: number;
   startTime: string;
+  endTime: string;
 };
 
 export type Routine = {

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -2,6 +2,7 @@ export type Task = {
   id: number;
   name: string;
   time: number;
+  startTime: string;
 };
 
 export type Routine = {

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -38,6 +38,7 @@ export type Plan = {
   arrivalAt: string;
   arrival: Location;
   departure: Location;
+  departureAt: string;
   belongings: string;
   memo: string;
   tasks: Task[];

--- a/packages/app/src/utils/date.ts
+++ b/packages/app/src/utils/date.ts
@@ -11,3 +11,10 @@ export const getHours = (date: string) => new Date(date).getHours();
 export const getMinutes = (date: string) => new Date(date).getMinutes();
 
 export const getMeridiem = (date: string) => (getHours(date) < 12 ? '오전' : '오후');
+
+export const timeText = (strings: TemplateStringsArray, ...exp: (boolean | string | number)[]) => {
+  return strings.reduce((prev, cur, idx) => {
+    const result = prev.concat(cur);
+    return exp[idx] ? result.concat(exp[idx].toString()) : result;
+  }, '');
+};

--- a/packages/app/src/utils/date.ts
+++ b/packages/app/src/utils/date.ts
@@ -1,14 +1,19 @@
+import { toDate } from 'date-fns-tz';
+
+export const toSeoulDate = (date: Date | string | number) =>
+  toDate(date, { timeZone: 'Asia/Seoul' });
+
 export const getDay = (date: string) => {
-  const day = new Date(date).getDay();
+  const day = toSeoulDate(date).getDay();
   return ['일', '월', '화', '수', '목', '금', '토'][day];
 };
 
-export const getMonth = (date: string) => new Date(date).getMonth() + 1;
-export const getDate = (date: string) => new Date(date).getDate();
-export const getYear = (date: string) => new Date(date).getFullYear();
+export const getMonth = (date: string) => toSeoulDate(date).getMonth() + 1;
+export const getDate = (date: string) => toSeoulDate(date).getDate();
+export const getYear = (date: string) => toSeoulDate(date).getFullYear();
 
-export const getHours = (date: string) => new Date(date).getHours();
-export const getMinutes = (date: string) => new Date(date).getMinutes();
+export const getHours = (date: string) => toSeoulDate(date).getHours();
+export const getMinutes = (date: string) => toSeoulDate(date).getMinutes();
 
 export const getMeridiem = (date: string) => (getHours(date) < 12 ? '오전' : '오후');
 

--- a/packages/app/src/utils/index.ts
+++ b/packages/app/src/utils/index.ts
@@ -2,6 +2,7 @@ import { PixelRatio, Platform } from 'react-native';
 
 import { GUIDELINE_BASE_WIDTH } from 'constant/index';
 import { SCREEN_WIDTH } from 'theme/Metrics';
+import { toSeoulDate } from './date';
 
 export const normalize = (size: number): number => {
   const newSize = size * (SCREEN_WIDTH / GUIDELINE_BASE_WIDTH);
@@ -14,7 +15,7 @@ export const normalize = (size: number): number => {
 };
 
 export const isInProgress = (start: string, end: string) => {
-  const currentDate = new Date();
-  return new Date(start) < currentDate && currentDate < new Date(end);
+  const currentDate = toSeoulDate(new Date());
+  return toSeoulDate(start) < currentDate && currentDate < toSeoulDate(end);
 };
 export const mod = (n: number, m: number) => ((n % m) + m) % m;

--- a/packages/app/src/utils/index.ts
+++ b/packages/app/src/utils/index.ts
@@ -17,3 +17,4 @@ export const isInProgress = (start: string, end: string) => {
   const currentDate = new Date();
   return new Date(start) < currentDate && currentDate < new Date(end);
 };
+export const mod = (n: number, m: number) => ((n % m) + m) % m;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2807,6 +2807,7 @@ __metadata:
     babel-plugin-module-resolver: ^4.1.0
     babel-plugin-styled-components: ^1.13.3
     date-fns: ^2.27.0
+    date-fns-tz: ^1.2.2
     design-token: "workspace:1.0.0"
     expo: ~43.0.2
     expo-font: ~10.0.3
@@ -4621,6 +4622,15 @@ __metadata:
   version: 1.0.1
   resolution: "cyclist@npm:1.0.1"
   checksum: 3cc2fdeb358599ca0ea96f5ecf2fc530ccab7ed1f8aa1a894aebfacd2009281bd7380cb9b30db02a18cdd00b3ed1d7ce81a3b11fe56e33a6a0fe4424dc592fbe
+  languageName: node
+  linkType: hard
+
+"date-fns-tz@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "date-fns-tz@npm:1.2.2"
+  peerDependencies:
+    date-fns: ">=2.0.0"
+  checksum: 90c5145499570736cd004cfb13f8a9bbc9de514ceb92224ccd6fd2e0d88e0d55ab1d4e279500653d2df7cca0002c88a1ce0768c8531cbf6063cce91a1e4e78d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 관련 이슈 연결
* it closes #213 
* it closes #215 

## 변경/추가 사항, 자세한 설명
* 홈의 최상단 컴포넌트의 시간 계산 기능 구현하였습니다.
* 슬랙에서 공유한대로 부모컴포넌트(TopContents/index)에서 ref로 자식 컴포넌트에 내려 시간을 업데이트하였습니다.
* 일정이 준비중~도착 전일 경우 "진행 중인 일정"을 렌더링합니다.

## 그 외 전달 사항
🥕개어려웡🥕
아마 버그 투성이일 것 같아서, 자세하게 봐주시면 감사하겠습니다~!~!

**혹시 테스트하실 땐 `db.json`에서 스케줄의 날짜와 시간을 변경해주는 것 잊지 마세요🙌**

## 최종 결과물 스크린샷

<img src="https://user-images.githubusercontent.com/49540564/151172855-e879c221-857b-401b-a635-6977761bea28.gif" width=400/>

<img src="https://user-images.githubusercontent.com/49540564/152303628-0e3fd824-c624-4e2c-88ad-bba0c38987f0.png" width=400/>

